### PR TITLE
Issue/10 - Adds support to fetch all fields in get_results.

### DIFF
--- a/query.php
+++ b/query.php
@@ -2791,6 +2791,11 @@ class Query extends Base {
 			return null;
 		}
 
+		// Get all columns, if specified.
+		if ( '*' === $cols ) {
+			$cols = $this->get_column_names();
+		}
+
 		// Fetch all the columns for the table being queried.
 		$column_names = $this->get_column_names();
 

--- a/query.php
+++ b/query.php
@@ -2793,7 +2793,7 @@ class Query extends Base {
 
 		// Get all columns, if specified.
 		if ( '*' === $cols ) {
-			$cols = array_keys( $this->get_column_names() );
+			$cols = $this->get_column_names();
 		}
 
 		// Fetch all the columns for the table being queried.

--- a/query.php
+++ b/query.php
@@ -2793,7 +2793,7 @@ class Query extends Base {
 
 		// Get all columns, if specified.
 		if ( '*' === $cols ) {
-			$cols = $this->get_column_names();
+			$cols = array_keys( $this->get_column_names() );
 		}
 
 		// Fetch all the columns for the table being queried.


### PR DESCRIPTION
Fixes #10 

This makes it possible to pass an asterisk in the `$cols` argument, and fetch all fields for the current table.

This isn't a true 1:1 representation of `SELECT *`, instead, there's a tiny bit of logic that tells `get_results` to transform `*` into the column names via `get_column_names()`. I believe this will ensure compatibility with other facets of this class.