### PR TITLE
Extracts clause creation into clause methods.

### DIFF
--- a/query.php
+++ b/query.php
@@ -1812,36 +1812,6 @@ class Query extends Base {
 		return $result;
 	}
 
-	public function update_many( $set, $where ) {
-
-		if ( ! is_array( $set ) ) {
-			$set = array( $set );
-		}
-
-		if ( ! is_array( $where ) ) {
-			$where = array( $where );
-		}
-
-		$where_clause = $this->where_clause( $where );
-		$set_clause   = $this->set_clause( $set );
-
-		// Bail early if the either clause is empty.
-		if ( empty( $where_clause ) || empty( $set_clause ) ) {
-			return false;
-		}
-
-		$query = "UPDATE {$this->get_table_name()} {$this->table_alias} ";
-		$query .= $set_clause . " ";
-		$query .= $where_clause;
-
-		return $query;
-		// Execute query.
-//		$results = $this->get_db()->get_results( $query, $output );
-
-		// Return results.
-//		return $results;
-	}
-
 	/**
 	 * Delete an item from the database
 	 *

--- a/query.php
+++ b/query.php
@@ -1812,6 +1812,36 @@ class Query extends Base {
 		return $result;
 	}
 
+	public function update_many( $set, $where ) {
+
+		if ( ! is_array( $set ) ) {
+			$set = array( $set );
+		}
+
+		if ( ! is_array( $where ) ) {
+			$where = array( $where );
+		}
+
+		$where_clause = $this->where_clause( $where );
+		$set_clause   = $this->set_clause( $set );
+
+		// Bail early if the either clause is empty.
+		if ( empty( $where_clause ) || empty( $set_clause ) ) {
+			return false;
+		}
+
+		$query = "UPDATE {$this->get_table_name()} {$this->table_alias} ";
+		$query .= $set_clause . " ";
+		$query .= $where_clause;
+
+		return $query;
+		// Execute query.
+//		$results = $this->get_db()->get_results( $query, $output );
+
+		// Return results.
+//		return $results;
+	}
+
 	/**
 	 * Delete an item from the database
 	 *

--- a/query.php
+++ b/query.php
@@ -2816,7 +2816,7 @@ class Query extends Base {
 
 			// Basic WHERE clause.
 			if ( ! is_array( $compare ) ) {
-				$where_clause .= " AND {$this->table_alias}.{$column} = {$compare}";
+				$where_clause .= " AND {$this->table_alias}.{$column} = '{$compare}'";
 
 				// More complex WHERE clause.
 			} else {


### PR DESCRIPTION
Part of #18 
Originally, this was a work-in progress implementation to add support for `update_many` method.

While working on this, I also made a significant set of changes to the `get_results` method. Originally, this method had several sanitization steps for each clause baked directly into the method. This update has broken each clause into their own method. This makes it easier to build secure queries that don't fall in-line with the `get_results` method.

I anticipate that these methods will prove to be useful when building custom queries outside of the what `get_results` can't do on its own.

These methods will also make it easier to build in support for `JOIN` statements in the future.

See https://github.com/berlindb/core/pull/20/commits/4f6fa92448eb3f9908bc4384180e404947b807ee