### PR TITLE
Issue/27 - Query: in clean_item_cache(), make an array instead of cast to array.

### DIFF
--- a/query.php
+++ b/query.php
@@ -2542,7 +2542,7 @@ class Query extends Base {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $items
+	 * @param mixed $items Single object item, or Array of object items
 	 *
 	 * @return bool
 	 */
@@ -2554,7 +2554,11 @@ class Query extends Base {
 		}
 
 		// Make sure items are an array
-		$items  = (array) $items;
+		if ( ! is_array( $items ) ) {
+			$items = array( $items );
+		}
+
+		// Get all cache groups
 		$groups = $this->get_cache_groups();
 
 		// Loop through all items and clean them


### PR DESCRIPTION
This commit fixes a bug that was preventing single item caches from being cleaned when an item was deleted.

Props felipeelia.
Fixes #27.