### PR TITLE
Updates delete_metadata_by_mid to use table name, not the parsed meta table name. #51

### DIFF
--- a/query.php
+++ b/query.php
@@ -2334,7 +2334,7 @@ class Query extends Base {
 
 		// Delete all meta data for this item ID
 		foreach ( $meta_ids as $mid ) {
-			delete_metadata_by_mid( $this->table_name, $mid );
+			delete_metadata_by_mid( $this->item_name, $mid );
 		}
 	}
 

--- a/query.php
+++ b/query.php
@@ -2334,7 +2334,7 @@ class Query extends Base {
 
 		// Delete all meta data for this item ID
 		foreach ( $meta_ids as $mid ) {
-			delete_metadata_by_mid( $table, $mid );
+			delete_metadata_by_mid( $this->table_name, $mid );
 		}
 	}
 


### PR DESCRIPTION
This change resolves this problem because `delete_metadata_by_mid` uses `_get_meta_table` to retrieve the meta table from the database. This function automatically appends `meta` to the table name, and does not need a prefix.

Due to this, there is no need to do anything but directly pass `table_name` to `delete_metadata_by_mid`.

Resolves #51 