### PR TITLE
Updates upgrade filter to use the upgrade version instead of the callback

### DIFF
--- a/table.php
+++ b/table.php
@@ -514,9 +514,9 @@ abstract class Table extends Base {
 		$result = false;
 
 		// Remove all upgrades that have already been completed
-		$upgrades = array_filter( (array) $this->upgrades, function( $value ) {
-			return version_compare( $value, $this->db_version, '>' );
-		} );
+		$upgrades = array_filter( (array) $this->upgrades, function( $upgrade_version ) {
+			return version_compare( $upgrade_version, $this->db_version, '>' );
+		}, ARRAY_FILTER_USE_KEY );
 
 		// Bail if no upgrades or database version is missing
 		if ( empty( $upgrades ) || empty( $this->db_version ) ) {

--- a/table.php
+++ b/table.php
@@ -512,14 +512,7 @@ abstract class Table extends Base {
 	 */
 	public function upgrade() {
 		$result   = false;
-		$upgrades = array();
-
-		// Remove all upgrades that have already been completed
-		foreach ( $this->upgrades as $version => $method ) {
-			if ( true === version_compare( $version, $this->db_version, '>' ) ) {
-				$upgrades[ $version ] = $method;
-			}
-		}
+		$upgrades = $this->get_queued_upgrades();
 
 		// Bail if no upgrades or database version is missing
 		if ( empty( $upgrades ) || empty( $this->db_version ) ) {
@@ -540,6 +533,26 @@ abstract class Table extends Base {
 
 		// Success/fail
 		return $this->is_success( $result );
+	}
+
+	/**
+	 * Retrieves the list of upgrades that still need to run.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array List of upgrade methods keyed by their db version.
+	 */
+	private function get_queued_upgrades() {
+		$upgrades = array();
+
+		// Remove all upgrades that have already been completed
+		foreach ( $this->upgrades as $version => $method ) {
+			if ( true === version_compare( $version, $this->db_version, '>' ) ) {
+				$upgrades[ $version ] = $method;
+			}
+		}
+
+		return $upgrades;
 	}
 
 	/**

--- a/table.php
+++ b/table.php
@@ -515,7 +515,7 @@ abstract class Table extends Base {
 		$upgrades = array();
 
 		// Remove all upgrades that have already been completed
-		foreach ( $upgrades as $version => $method ) {
+		foreach ( $this->upgrades as $version => $method ) {
 			if ( true === version_compare( $version, $this->db_version, '>' ) ) {
 				$upgrades[ $version ] = $method;
 			}

--- a/table.php
+++ b/table.php
@@ -511,16 +511,20 @@ abstract class Table extends Base {
 	 * return bool
 	 */
 	public function upgrade() {
-		$result = false;
+		$result   = false;
+		$upgrades = array();
 
 		// Remove all upgrades that have already been completed
-		$upgrades = array_filter( (array) $this->upgrades, function( $upgrade_version ) {
-			return version_compare( $upgrade_version, $this->db_version, '>' );
-		}, ARRAY_FILTER_USE_KEY );
+		foreach ( $upgrades as $version => $method ) {
+			if ( true === version_compare( $version, $this->db_version, '>' ) ) {
+				$upgrades[ $version ] = $method;
+			}
+		}
 
 		// Bail if no upgrades or database version is missing
 		if ( empty( $upgrades ) || empty( $this->db_version ) ) {
 			$this->set_db_version();
+
 			return true;
 		}
 


### PR DESCRIPTION
We could potentially use a foreach loop here, but I figured I'd keep the code as similar as it was as possible. Basically, I just changed the filter to use the key of `$versions`, which is the version number. Prior to this, it un-intentionally used the values of `$versions`, which is supposed to be the callback.