### PR TITLE
Issue/55 - Make Query Class Extend-able

### DIFF
--- a/src/Database/Queries/Query_Processor.php
+++ b/src/Database/Queries/Query_Processor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Query_Processor Class
+ *
+ * @since 2.0.0
+ * @package BerlinDB\Database\Queries
+ */
+
+
+namespace BerlinDB\Database\Queries;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Processes custom extendable query params
+ *
+ *
+ * @since 2.0.0
+ * @package BerlinDB\Database\Queries
+ */
+abstract class Query_Processor extends Base {
+
+	/**
+	 * The arguments passed by the query
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var array array of arguments.
+	 */
+	private $query_args = array();
+
+	/**
+	 * Query_Processor constructor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param $query_args array of query arguments.
+	 */
+	public function __construct( $query_args ) {
+		$this->query_args = $query_args;
+	}
+
+	/**
+	 * Parse the where clause specific to this processor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $column The current column.
+	 * @return string The where clause for this column. If left empty, the clause will not be added.
+	 */
+	abstract public function parse_where( $column );
+
+	/**
+	 * Parse the join clause specific to this processor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return string The join clause for this processor.
+	 */
+	abstract public function parse_join();
+}

--- a/src/Database/Queries/Query_Registry.php
+++ b/src/Database/Queries/Query_Registry.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Class Query Registry
+ *
+ * @since   2.0.0
+ * @package BerlinDB\Database\Queries
+ */
+
+
+namespace BerlinDB\Database\Queries;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers different query processors
+ *
+ *
+ * @since 2.0.0
+ * @package
+ */
+class Query_Registry extends \ArrayIterator {
+
+	private $query_args = array();
+
+	public function __construct( $query_args ) {
+		parent::__construct();
+		$this->query_args = $query_args;
+
+		// Register processors
+		foreach ( (array) apply_filters( 'berlin_db_query_processors', array() ) as $key => $class ) {
+			$this->add( $key, $class );
+		}
+	}
+
+	/**
+	 * Adds an item to the registry
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $key   The key to use when referencing this class
+	 * @param mixed  $class The class name to instantiate when this key is called.
+	 * @return boolean true if the item was set, otherwise false.
+	 */
+	public function add( $key, $class ) {
+		$valid = is_subclass_of( $class, 'BerlinDB\Database\Queries\Query_Processor' );
+
+		if ( $valid ) {
+			$this[ $key ] = $class;
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Retrieves a registered item.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $key The identifier for the item.
+	 * @return Query_Processor|false the item value, if it is set. Otherwise, false.
+	 */
+	public function get( $key ) {
+		if ( isset( $this[ $key ] ) && is_string( $this[ $key ] ) ) {
+			$this[ $key ] = new $this[ $key ]( $this->query_args );
+
+			return $this[ $key ];
+		}
+
+		return false;
+	}
+}

--- a/src/Database/Queries/Query_Registry.php
+++ b/src/Database/Queries/Query_Registry.php
@@ -62,12 +62,14 @@ class Query_Registry extends \ArrayIterator {
 	 * @return Query_Processor|false the item value, if it is set. Otherwise, false.
 	 */
 	public function get( $key ) {
-		if ( isset( $this[ $key ] ) && is_string( $this[ $key ] ) ) {
-			$this[ $key ] = new $this[ $key ]( $this->query_args );
-
-			return $this[ $key ];
+		if ( ! isset( $this[ $key ] ) ) {
+			return false;
 		}
 
-		return false;
+		if ( is_string( $this[ $key ] ) ) {
+			$this[ $key ] = new $this[ $key ]( $this->query_args );
+		}
+
+		return $this[ $key ];
 	}
 }


### PR DESCRIPTION
This is _totally_ not event close to being finished, but I wanted to submit some of my initial thoughts about how this could be put together. This is mostly intended to spark discussion and thoughts about how it can be handled moving forward.

Basically, to register a custom query processor, you would extend `Query_Processor`, and register that processor to the registry. This is currently done via a filter that runs each time the registry is constructed.

The query class would then loop through the registered items while parsing important parts of the query, such as `select`, `where`, `join`, `group_by`, etc.

In this PR I have set up a rough idea on what I think `join` and `where` could be.

This has not been tested in any fashion - just mostly focusing in on the "big conversations" about how the system could be structured.

Issue #55