### PR TITLE
Issue/61 - Refactor prepare_query to be extend-able directly by queries

### DIFF
--- a/query.php
+++ b/query.php
@@ -345,7 +345,7 @@ class Query extends Base {
 	 * @return array|int List of items, or number of items when 'count' is passed as a query var.
 	 */
 	public function query( $query = array() ) {
-		$this->parse_query( $query );
+		$this->prepare_query( $query );
 
 		return $this->get_items();
 	}
@@ -1094,7 +1094,7 @@ class Query extends Base {
 	 *
 	 * @param string|array $query Array or string of Query arguments.
 	 */
-	private function parse_query( $query = array() ) {
+	private function prepare_query( $query = array() ) {
 
 		// Setup the query_vars_original var
 		$this->query_var_originals = wp_parse_args( $query );

--- a/query.php
+++ b/query.php
@@ -1105,6 +1105,15 @@ class Query extends Base {
 			$this->query_var_defaults
 		);
 
+		$this->parse_query();
+	}
+
+	/**
+	 * Parses arguments passed to the item query with default query parameters.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function parse_query(){
 		/**
 		 * Fires after the item query vars have been parsed.
 		 *


### PR DESCRIPTION
I brought this up in issue #61

The intent here is to make it possible for child classes to extend `prepare_query` without utilizing WordPress hooks. The key benefit of this is better-control over this hook, and to make it easier for direct integrations to extend the Query class. Without this, the only way to extend Query is through hooks, which in the context of a child class is awkward.

To better-articulate the goal, this makes it possible for a child class to directly view the query arguments, and manipulate the actual query that comes through. This is a little different than a query processor in-that it isn't a BerlinDB-wide integration, but instead a query-specific integration.

Say, for example, you want to fetch data by querying a pivot table. This would make it possible to add query args for this specific type of query that can tell it to JOIN the other tables in the pivot table with minimal changes to how the system works elsewhere.