### PR TITLE
Issue/76-jjj - Nulls: validate null values if allowed, on any column.

### DIFF
--- a/column.php
+++ b/column.php
@@ -678,7 +678,7 @@ class Column extends Base {
 			return wp_kses_data( $default );
 
 		// Integer
-		} elseif ( $this->is_numeric( $default ) ) {
+		} elseif ( $this->is_numeric() ) {
 			return (int) $default;
 		}
 

--- a/column.php
+++ b/column.php
@@ -668,9 +668,24 @@ class Column extends Base {
 	 * @return string|null
 	 */
 	private function sanitize_default( $default = '' ) {
-		return is_null( $default )
-			? null
-			: wp_kses_data( $default );
+
+		// Null
+		if ( ( true === $this->allow_null ) && is_null( $default ) ) {
+			return null;
+
+		// String
+		} elseif ( is_string( $default ) ) {
+			return wp_kses_data( $default );
+
+		// Integer
+		} elseif ( $this->is_numeric( $default ) ) {
+			return (int) $default;
+		}
+
+		// @todo datetime, decimal, and other column types
+
+		// Unknown, so return the default's default
+		return '';
 	}
 
 	/**
@@ -749,7 +764,7 @@ class Column extends Base {
 
 		// Handle "empty" values
 		if ( empty( $value ) || ( '0000-00-00 00:00:00' === $value ) ) {
-			$value = ! empty( $this->default ) || ( ( true === $this->allow_null ) && is_null( $this->default ) )
+			$value = ! empty( $this->default )
 				? $this->default
 				: '';
 

--- a/query.php
+++ b/query.php
@@ -8,7 +8,7 @@
  * @license     https://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       1.0.0
  */
-namespace Sugar_Calendar\Database;
+namespace BerlinDB\Database;
 
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;

--- a/query.php
+++ b/query.php
@@ -2001,8 +2001,8 @@ class Query extends Base {
 				}
 
 			// Attempt to validate
-			} elseif ( ! empty( $column->callback ) && is_callable( $column->callback ) ) {
-				$validated = call_user_func( $column->callback, $value );
+			} elseif ( ! empty( $column->validate ) && is_callable( $column->validate ) ) {
+				$validated = call_user_func( $column->validate, $value );
 
 				// Bail if error
 				if ( is_wp_error( $validated ) ) {

--- a/query.php
+++ b/query.php
@@ -1984,21 +1984,25 @@ class Query extends Base {
 		// Loop through item attributes
 		foreach ( $item as $key => $value ) {
 
-			// Only allow null if column allows null
-			if ( is_null( $value ) && $this->get_column_field( array( 'name' => $key ), 'allow_null' ) ) {
-				$value = null;
-
 			// Strip slashes from all strings
-			} elseif ( is_string( $value ) ) {
+			if ( is_string( $value ) ) {
 				$value = stripslashes( $value );
 			}
 
-			// Get callback for column
-			$callback = $this->get_column_field( array( 'name' => $key ), 'validate' );
+			// Get column
+			$column = $this->get_column_by( array( 'name' => $key ) );
+
+			// Null value is special for all item keys
+			if ( is_null( $value ) ) {
+
+				// Bail if null is not allowed
+				if ( false === $column->allow_null ) {
+					return false;
+				}
 
 			// Attempt to validate
-			if ( ! empty( $callback ) && is_callable( $callback ) ) {
-				$validated = call_user_func( $callback, $value );
+			} elseif ( ! empty( $column->callback ) && is_callable( $column->callback ) ) {
+				$validated = call_user_func( $column->callback, $value );
 
 				// Bail if error
 				if ( is_wp_error( $validated ) ) {


### PR DESCRIPTION
Up until now, the "Column::allow_null" flag was only partially implemented, working sometimes for "datetime" columns, but not for any others.

This commit ensures that, in the "Query::validate_item" method, null values for all item keys are allowed when "allow_null" is true for that column, and returns false early when attempting to save a null value to an item key when it is not allowed.

This commit also removes the special datetime, column type, null value handling that was added as part of #22, since it is now explicitly globally allowed (when allowed) in the global validator.

This commit also modifies "Column::sanitize_default" to only allow null defaults when "allow_null" is true, adds explicit support for strings and integers, and adds a @todo regarding other column types that may have their own unique default values (datetime, decimal, timestamp, and others come to mind).

Fixes #76.