### PR TITLE
Add support for 'start_of_week' first-order clause.

### DIFF
--- a/date.php
+++ b/date.php
@@ -237,16 +237,16 @@ class Date extends Base {
 			return;
 		}
 
-		// Support for passing time-based keys in the top level of the array.
-		if ( ! isset( $date_query[0] ) ) {
-			$date_query = array( $date_query );
-		}
-
 		// Set column, compare, relation, and start_of_week.
 		$this->column        = $this->get_column( $date_query );
 		$this->compare       = $this->get_compare( $date_query );
 		$this->relation      = $this->get_relation( $date_query );
 		$this->start_of_week = $this->get_start_of_week( $date_query );
+
+		// Support for passing time-based keys in the top level of the array.
+		if ( ! isset( $date_query[0] ) ) {
+			$date_query = array( $date_query );
+		}
 
 		// Set the queries
 		$this->queries       = $this->sanitize_query( $date_query );

--- a/date.php
+++ b/date.php
@@ -777,7 +777,7 @@ class Date extends Base {
 		$lt = '<';
 		$gt = '>';
 
-		if ( $inclusive ) {
+		if ( true === $inclusive ) {
 			$lt .= '=';
 			$gt .= '=';
 		}

--- a/date.php
+++ b/date.php
@@ -411,7 +411,7 @@ class Date extends Base {
 	public function get_start_of_week( $query = array() ) {
 
 		// Use start of week if passed and valid
-		$retval = ! empty( $query['start_of_week'] ) && ( 6 >= (int) $query['start_of_week'] ) && ( 0 <= (int) $query['start_of_week'] )
+		$retval = isset( $query['start_of_week'] ) && ( 6 >= (int) $query['start_of_week'] ) && ( 0 <= (int) $query['start_of_week'] )
 			? $query['start_of_week']
 			: $this->start_of_week;
 


### PR DESCRIPTION
This commit is necessary to remove dependency on `get_option( 'start_of_week' )` WordPress setting.

This commit includes some code formatting changes to align surrounding lines as needed.

Fixes #80 