### PR TITLE
Issue/84 - Query: introduce get_meta_type() and improve get_meta_table_name()

### DIFF
--- a/query.php
+++ b/query.php
@@ -1127,16 +1127,14 @@ class Query extends Base {
 	/**
 	 * Parse the where clauses for all known columns
 	 *
+	 * @todo split this method into smaller parts
+	 *
 	 * @since 1.0.0
 	 */
 	private function parse_where() {
 
 		// Defaults
 		$where = $join = $searchable = $date_query = array();
-		$and   = '/^\s*AND\s*/';
-
-		// Set the table right away
-		$table = $this->apply_prefix( $this->item_name );
 
 		// Loop through columns
 		foreach ( $this->columns as $column ) {
@@ -1276,11 +1274,18 @@ class Query extends Base {
 			$where['search'] = $this->get_search_sql( $this->query_vars['search'], $search_columns );
 		}
 
+		/** Query Classes *****************************************************/
+
+		// Get the primary column & table
+		$primary = $this->get_primary_column_name();
+		$table   = $this->get_meta_type();
+		$and     = '/^\s*AND\s*/';
+
 		// Maybe perform a meta query.
 		$meta_query = $this->query_vars['meta_query'];
 		if ( ! empty( $meta_query ) && is_array( $meta_query ) ) {
 			$this->meta_query = $this->get_meta_query( $meta_query );
-			$clauses          = $this->meta_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses          = $this->meta_query->get_sql( $table, $this->table_alias, $primary, $this );
 
 			// Not all objects have meta, so make sure this one exists
 			if ( false !== $clauses ) {
@@ -1299,10 +1304,15 @@ class Query extends Base {
 		$compare_query = $this->query_vars['compare_query'];
 		if ( ! empty( $compare_query ) && is_array( $compare_query ) ) {
 			$this->compare_query = $this->get_compare_query( $compare_query );
-			$clauses             = $this->compare_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses             = $this->compare_query->get_sql( $table, $this->table_alias, $primary, $this );
 
 			// Not all objects can compare, so make sure this one exists
 			if ( false !== $clauses ) {
+
+				// Set join
+				if ( ! empty( $clauses['join'] ) ) {
+					$join['compare_query'] = $clauses['join'];
+				}
 
 				// Remove " AND " from query where clause.
 				$where['compare_query'] = preg_replace( $and, '', $clauses['where'] );
@@ -1317,10 +1327,15 @@ class Query extends Base {
 		// Maybe perform a date query
 		if ( ! empty( $date_query ) && is_array( $date_query ) ) {
 			$this->date_query = $this->get_date_query( $date_query );
-			$clauses          = $this->date_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses          = $this->date_query->get_sql( $this->table_name, $this->table_alias, $primary, $this );
 
 			// Not all objects are dates, so make sure this one exists
 			if ( false !== $clauses ) {
+
+				// Set join
+				if ( ! empty( $clauses['join'] ) ) {
+					$join['date_query'] = $clauses['join'];
+				}
 
 				// Remove " AND " from query where clause.
 				$where['date_query'] = preg_replace( $and, '', $clauses['where'] );
@@ -2196,16 +2211,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return add_metadata( $table, $item_id, $meta_key, $meta_value, $unique );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of adding meta data
+		return add_metadata( $meta_type, $item_id, $meta_key, $meta_value, $unique );
 	}
 
 	/**
@@ -2226,16 +2241,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return get_metadata( $table, $item_id, $meta_key, $single );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of getting meta data
+		return get_metadata( $meta_type, $item_id, $meta_key, $single );
 	}
 
 	/**
@@ -2257,16 +2272,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return update_metadata( $table, $item_id, $meta_key, $meta_value, $prev_value );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of updating meta data
+		return update_metadata( $meta_type, $item_id, $meta_key, $meta_value, $prev_value );
 	}
 
 	/**
@@ -2288,16 +2303,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return delete_metadata( $table, $item_id, $meta_key, $meta_value, $delete_all );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of deleting meta data
+		return delete_metadata( $meta_type, $item_id, $meta_key, $meta_value, $delete_all );
 	}
 
 	/**
@@ -2312,7 +2327,7 @@ class Query extends Base {
 	private function get_registered_meta_keys( $object_subtype = '' ) {
 
 		// Get the object type
-		$object_type = $this->apply_prefix( $this->item_name );
+		$object_type = $this->get_meta_type();
 
 		// Return the keys
 		return get_registered_meta_keys( $object_type, $object_subtype );
@@ -2333,11 +2348,8 @@ class Query extends Base {
 			return;
 		}
 
-		// Get meta table name
-		$table = $this->get_meta_table_name();
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return;
 		}
 
@@ -2395,14 +2407,20 @@ class Query extends Base {
 			return;
 		}
 
+		// Get the meta type
+		$meta_type = $this->get_meta_type();
+
 		// Delete all meta data for this item ID
 		foreach ( $meta_ids as $mid ) {
-			delete_metadata_by_mid( $this->item_name, $mid );
+			delete_metadata_by_mid( $meta_type, $mid );
 		}
 	}
 
 	/**
-	 * Return meta table
+	 * Get the meta table for this query
+	 *
+	 * Forked from WordPress\_get_meta_table() so it can be more accurately
+	 * predicted in a future iteration and default to returning false.
 	 *
 	 * @since 1.0.0
 	 *
@@ -2410,11 +2428,36 @@ class Query extends Base {
 	 */
 	private function get_meta_table_name() {
 
-		// Maybe apply table prefix
-		$table = $this->apply_prefix( $this->item_name );
+		// Get the meta-type
+		$type       = $this->get_meta_type();
 
-		// Return table if exists, or false if not
-		return _get_meta_table( $table );
+		// Append "meta" to end of meta-type
+		$table_name = "{$type}meta";
+
+		// Variable'ize the database interface, to use inside empty()
+		$db         = $this->get_db();
+
+		// If not empty, return table name
+		if ( ! empty( $db->{$table_name} ) ) {
+			return $table_name;
+		}
+
+		// Default return false
+		return false;
+	}
+
+	/**
+	 * Get the meta type for this query
+	 *
+	 * This method exists to reduce some duplication for now. Future iterations
+	 * will likely use Column::relationships to
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	private function get_meta_type() {
+		return $this->apply_prefix( $this->item_name );
 	}
 
 	/** Cache *****************************************************************/


### PR DESCRIPTION
This change fixes delete_all_item_meta() and allows proper deletion of meta data when a Row is deleted via a Query.

It acheives this by using the correct meta-type string for the given meta data action taking place, thanks to the way that _get_meta_table() works internally.

Fixes #84 