### PR TITLE
Query: add copy_item() method.

### DIFF
--- a/query.php
+++ b/query.php
@@ -1809,6 +1809,38 @@ class Query extends Base {
 	}
 
 	/**
+	 * Copy an item in the database to a new item.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $item_id
+	 * @param array $data
+	 * @return bool
+	 */
+	public function copy_item( $item_id = 0, $data = array() ) {
+
+		// Get the primary column name
+		$primary = $this->get_primary_column_name();
+
+		// Get item by ID (from database, not cache)
+		$item    = $this->get_item_raw( $primary, $item_id );
+
+		// Bail if item does not exist
+		if ( empty( $item ) ) {
+			return false;
+		}
+
+		// Merge data with original item
+		$save = array_merge( $item, $data );
+
+		// Unset the primary key
+		unset( $save[ $primary ] );
+
+		// Return result
+		return $this->add_item( $save );
+	}
+
+	/**
 	 * Update an item in the database.
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
This change introduces a way to allow for copying an existing item/Row in the database, with the option to override that data via the $data parameter.

The goal of including this method as a low-level API is to reduce the amount of code necessary to support this action higher up in the application layer (global functions, etc...)

Fixes #88 