### PR TITLE
Table: fix format of query inside index_exists().

### DIFF
--- a/table.php
+++ b/table.php
@@ -591,10 +591,15 @@ abstract class Table extends Base {
 			return false;
 		}
 
+		// Limit $column to Key or Column name, until we can do better
+		if ( ! in_array( $column, array( 'Key_name', 'Column_name' ), true ) ) {
+			$column = 'Key_name';
+		}
+
 		// Query statement
-		$query    = "SHOW INDEXES FROM {$this->table_name} WHERE %s LIKE %s";
+		$query    = "SHOW INDEXES FROM {$this->table_name} WHERE {$column} LIKE %s";
 		$like     = $db->esc_like( $name );
-		$prepared = $db->prepare( $query, $column, $like );
+		$prepared = $db->prepare( $query, $like );
 		$result   = $db->query( $prepared );
 
 		// Does the index exist?


### PR DESCRIPTION
This change prevents quotes around the $column value by not preparing it, and also by making sure its value is only 1 of 2 intended columns: Key_name and Column_name.

This fixes incorrectly generated SQL, allowing this method to function as intended instead of incorrectly returning no results.

Props @ashleyfae. Fixes #87.