### PR TITLE
Issue/97 - Query: remove stripslashes() in ::validate_item()

### DIFF
--- a/query.php
+++ b/query.php
@@ -2052,11 +2052,6 @@ class Query extends Base {
 		// Loop through item attributes
 		foreach ( $item as $key => $value ) {
 
-			// Strip slashes from all strings
-			if ( is_string( $value ) ) {
-				$value = stripslashes( $value );
-			}
-
 			// Get the column
 			$column = $this->get_column_by( array( 'name' => $key ) );
 


### PR DESCRIPTION
This change removes the forced stripping of slashes on string content columns before saving them to the database.

Based on developer feedback, the consensus is that this decision belongs higher up in the application stack, and not in a low-level database API.

Fixes #97.