### PR TITLE
Issue/106 - Query: pass $alias from parse_fields() into parse_groupby() call.

### DIFF
--- a/query.php
+++ b/query.php
@@ -1389,7 +1389,7 @@ class Query extends Base {
 		if ( empty( $fields ) && ! empty( $this->query_vars['count'] ) ) {
 
 			// Possible fields to group by
-			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], false );
+			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], $alias );
 			$groupby_names = ! empty( $groupby_names )
 				? "{$groupby_names}"
 				: '';


### PR DESCRIPTION
This change ensures that, by default, parsing the groupby clause of a query will match the behavior of parsing fields.

See #106.