### PR TITLE
Table: add _clone() shim from Sugar Calendar.

### DIFF
--- a/src/Database/Table.php
+++ b/src/Database/Table.php
@@ -160,6 +160,24 @@ abstract class Table extends Base {
 		}
 	}
 
+	/**
+ 	 * Compatibility for clone() method for PHP versions less than 7.0.
+ 	 *
+ 	 * See: https://github.com/sugarcalendar/core/issues/105
+ 	 *
+ 	 * This shim will be removed at a later date.
+ 	 *
+ 	 * @since 2.0.20
+ 	 *
+ 	 * @param string $function
+ 	 * @param array  $args
+ 	 */
+ 	public function __call( $function = '', $args = array() ) {
+ 		if ( 'clone' === $function ) {
+ 			call_user_func_array( array( $this, '_clone' ), $args );
+ 		}
+ 	}
+
 	/** Abstract **************************************************************/
 
 	/**
@@ -488,7 +506,7 @@ abstract class Table extends Base {
 	 *
 	 * @return bool
 	 */
-	public function clone( $new_table_name = '' ) {
+	public function _clone( $new_table_name = '' ) {
 
 		// Get the database interface
 		$db = $this->get_db();


### PR DESCRIPTION
For PHP 5.6 compatibility.

Fixes #38.