### PR TITLE
Create dynamic hook after an item is deleted

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2035,6 +2035,16 @@ class Query extends Base {
 		$this->delete_all_item_meta( $item_id );
 		$this->clean_item_cache( $item );
 
+		/**
+		 * Fires after an object has been deleted.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param int   $item_id The ID of the item that was deleted.
+		 * @param bool  $result  Whether the item was successfully deleted.
+		 */
+		do_action( $this->apply_prefix( "{$this->item_name}_deleted" ), $item_id, $result );
+
 		// Return result
 		return $result;
 	}


### PR DESCRIPTION
Fixes #132

Proposed Changes:
1. Registers a new dynamic hook (eg `edd_order_deleted`) when an item is deleted. The two parameters are the original item ID and the result of the delete action.