### PR TITLE
Set db version default to 1

### DIFF
--- a/src/Database/Table.php
+++ b/src/Database/Table.php
@@ -1158,8 +1158,8 @@ abstract class Table extends Base {
 	 */
 	private function get_db_version() {
 		$this->db_version = $this->is_global()
-			? get_network_option( get_main_network_id(), $this->db_version_key, false )
-			:         get_option(                        $this->db_version_key, false );
+			? get_network_option( get_main_network_id(), $this->db_version_key, 1 )
+			:         get_option(                        $this->db_version_key, 1 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #156

Proposed Changes:
Sets the default value for getting the table version from the database to `1`, an arbitrary and low number. This won't affect creating new tables, but if a table exists and does not have a version number, it will allow upgrades to be collected and run.