### PR TITLE
Use table alias/name when building date query

### DIFF
--- a/src/Database/Queries/Date.php
+++ b/src/Database/Queries/Date.php
@@ -152,6 +152,19 @@ class Date extends Base {
 		'AND'
 	);
 
+	
+	/**
+	 * @since 3.2.6
+	 * @var string|null Table name
+	 */
+	public $table_name = null;
+
+	/**
+	 * @since 3.2.6
+	 * @var string|null Table alias
+	 */
+	public $table_alias = null;
+
 	/**
 	 * Constructor.
 	 *
@@ -387,6 +400,12 @@ class Date extends Base {
 		$retval = ! empty( $query['column'] )
 			? esc_sql( $this->validate_column( $query['column'] ) )
 			: $this->column;
+
+		if (!empty($this->table_alias)) {
+			$retval = $this->table_alias . '.' . $retval;
+		} elseif (!empty($this->table_name)) {
+			$retval = $this->table_name . '.' . $retval;
+		}
 
 		return $retval;
 	}
@@ -645,8 +664,10 @@ class Date extends Base {
 	 *
 	 * @return string MySQL WHERE clauses.
 	 */
-	public function get_sql() {
-		$sql = $this->get_sql_clauses();
+	public function get_sql( $table_name = null, $table_alias = null ) {
+		$this->table_name  = $this->sanitize_table_name( $table_name );
+		$this->table_alias = $this->sanitize_table_name( $table_alias );
+		$sql               = $this->get_sql_clauses();
 
 		/**
 		 * Filters the date query clauses.

--- a/src/Database/Queries/Date.php
+++ b/src/Database/Queries/Date.php
@@ -154,16 +154,10 @@ class Date extends Base {
 
 	
 	/**
-	 * @since 3.2.6
+	 * @since 2.0.2
 	 * @var string|null Table name
 	 */
 	public $table_name = null;
-
-	/**
-	 * @since 3.2.6
-	 * @var string|null Table alias
-	 */
-	public $table_alias = null;
 
 	/**
 	 * Constructor.
@@ -664,9 +658,8 @@ class Date extends Base {
 	 *
 	 * @return string MySQL WHERE clauses.
 	 */
-	public function get_sql( $table_name = null, $table_alias = null ) {
-		$this->table_name  = $this->sanitize_table_name( $table_name );
-		$this->table_alias = $this->sanitize_table_name( $table_alias );
+	public function get_sql( $type, $primary_table, $primary_id_column, $context = null ) {
+		$this->table_name  = $this->sanitize_table_name( $primary_table );
 		$sql               = $this->get_sql_clauses();
 
 		/**

--- a/src/Database/Queries/Date.php
+++ b/src/Database/Queries/Date.php
@@ -395,9 +395,7 @@ class Date extends Base {
 			? esc_sql( $this->validate_column( $query['column'] ) )
 			: $this->column;
 
-		if (!empty($this->table_alias)) {
-			$retval = $this->table_alias . '.' . $retval;
-		} elseif (!empty($this->table_name)) {
+		if (!empty($this->table_name)) {
 			$retval = $this->table_name . '.' . $retval;
 		}
 


### PR DESCRIPTION
This PR attempts to fix the issue described in #9699 

Use the received table name & table alias arguments in the `get_sql` function to set those as properties on the Date class. Note that `get_sql` already gets called with those params as per the line below. However the `get_sql` function oddly wasn't defining those arguments in its definition.

 https://github.com/awesomemotive/easy-digital-downloads/blob/715373d18971c8b12e949bb3fd5d6c40aac6c234/includes/database/engine/class-query.php#L1363 

Then, when building the SQL query, use the alias or name (only if available) to prepend to the column name in the query. This prevents ambiguity issues when performing the SQL query

This prevents and fixes the issue described in https://github.com/awesomemotive/easy-digital-downloads/issues/9699

I am open to receiving feedback on the solution proposed and working on an updated solution. I am also not exactly sure how to test this change in the context of BerlinDB - but I have tested the fix in EDD as per my previous PR opened at https://github.com/awesomemotive/easy-digital-downloads/pull/9700

Thanks!
