### PR TITLE
Issue/160 - Query: always use `set_last_changed()` in `update_last_changed_cache()`

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2848,10 +2848,8 @@ class Query extends Base {
 	 */
 	private function update_last_changed_cache( $group = '' ) {
 
-		// Fallback to microtime
-		if ( empty( $this->last_changed ) ) {
-			$this->set_last_changed();
-		}
+		// Set last_changed to current microtime
+		$this->set_last_changed();
 
 		// Set the last changed time for this cache group
 		$this->cache_set( 'last_changed', $this->last_changed, $group );


### PR DESCRIPTION
This change ensures that anytime an item is updated or deleted, `last_changed` will also be set to the current microtime.

This fixes a bug where re-querying for items with the same `Query` instance that previously updated or deleted an item would return results that were out-of-date with the database, because `last_changed` was only ever set a single time.

Props spencerfinnell.

Fixes #160.