### PR TITLE
Issue/168 - Query: reset `fields` when counting.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1314,6 +1314,7 @@ class Query extends Base {
 		// If counting, override some other $query_vars
 		if ( $this->get_query_var( 'count' ) ) {
 			$this->query_vars['number']            = false;
+			$this->query_vars['fields']            = '';
 			$this->query_vars['orderby']           = '';
 			$this->query_vars['no_found_rows']     = true;
 			$this->query_vars['update_item_cache'] = false;


### PR DESCRIPTION
This change prevents unintended behavior when both the `count` and `fields` query variables are non-defaults, causing the SQL that is generated to be incomplete.

By resetting `fields` in `parse_query()`, we prioritize doing the standard full `COUNT(*)`.

(It is possible in the future that this gets reverted and both `count` and `fields` are supported, allowing for getting a count of any specific combination of columns/fields.)

Props robincornett.

Fixes #168.