### PR TITLE
Prefix column for compare queries

### DIFF
--- a/src/Database/Queries/Compare.php
+++ b/src/Database/Queries/Compare.php
@@ -165,7 +165,7 @@ class Compare extends Meta {
 
 			// Maybe add column, compare, & where to chunks
 			if ( ! empty( $where ) ) {
-				$sql_chunks['where'][] = "{$column} {$compare} {$where}";
+				$sql_chunks['where'][] = "{$this->primary_table}.{$column} {$compare} {$where}";
 			}
 		}
 


### PR DESCRIPTION
Fixes #180

Proposed Changes:
1. Adds the primary table prefix to the `$column` for a compare query.