### PR TITLE
Remove unset columns from cache keys

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -3402,13 +3402,11 @@ class Query extends Base {
 
 		// Remove unset columns (sentinel values) so identical logical queries
 		// produce identical cache keys across instances.
-		$sentinel = $this->query_var_default_value;
-		$slice    = array_filter(
-			$slice,
-			function ( $v ) use ( $sentinel ) {
-				return $v !== $sentinel;
+		foreach ( $slice as $key => $value ) {
+			if ( $value === $this->query_var_default_value ) {
+				unset( $slice[ $key ] );
 			}
-		);
+		}
 
 		// Setup key & last_changed.
 		$key          = md5( serialize( $slice ) );

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -396,7 +396,7 @@ class Query extends Base {
 	 * @since 1.0.0
 	 */
 	private function set_item_shape() {
-		
+
 		// Item shape
 		if ( empty( $this->item_shape ) || ! class_exists( $this->item_shape ) ) {
 			$this->item_shape = __NAMESPACE__ . '\\Row';
@@ -3394,17 +3394,27 @@ class Query extends Base {
 	 */
 	private function get_cache_key( $group = '' ) {
 
-		// Slice $query_vars by default keys
+		// Slice $query_vars by default keys.
 		$slice = wp_array_slice_assoc( $this->query_vars, array_keys( $this->query_var_defaults ) );
 
-		// Unset "fields" so it does not effect the cache key
+		// Unset "fields" so it does not affect the cache key.
 		unset( $slice['fields'] );
 
-		// Setup key & last_changed
+		// Remove unset columns (sentinel values) so identical logical queries
+		// produce identical cache keys across instances.
+		$sentinel = $this->query_var_default_value;
+		$slice    = array_filter(
+			$slice,
+			function ( $v ) use ( $sentinel ) {
+				return $v !== $sentinel;
+			}
+		);
+
+		// Setup key & last_changed.
 		$key          = md5( serialize( $slice ) );
 		$last_changed = $this->get_last_changed_cache( $group );
 
-		// Return the concatenated cache key
+		// Return the concatenated cache key.
 		return "get_{$this->item_name_plural}:{$key}:{$last_changed}";
 	}
 


### PR DESCRIPTION
Fixes #184

Proposed Changes:
1. Removes unset columns (sentinel values) from the array used to build the cache key.

If we get unit tests set up for Berlin, which I have a branch in progress for, here's the tests I've written for EDD which could be modified for Berlin:

```php
<?php
/**
 * Query-result cache tests for EDD\Database\Query.
 *
 * Verifies that the sentinel-stripping fix in get_cache_key() allows
 * BerlinDB's query-result cache to work correctly across Query instances.
 *
 * @package     EDD\Tests\Orders
 * @copyright   Copyright (c) 2026, Sandhills Development, LLC
 * @license     https://opensource.org/licenses/gpl-2.0.php GNU Public License
 * @since       <next-version>
 */

namespace EDD\Tests\Orders;

use EDD\Database\Queries\Order as Order_Query;
use EDD\Tests\PHPUnit\EDD_UnitTestCase;

/**
 * @coversDefaultClass \EDD\Database\Query
 */
class QueryCache extends EDD_UnitTestCase {

	/**
	 * Order fixture.
	 *
	 * @var int
	 */
	protected static $order_id;

	/**
	 * Set up fixtures once.
	 */
	public static function wpSetUpBeforeClass() {
		self::$order_id = parent::edd()->order->create();
	}

	/**
	 * Two separate Query instances with identical arguments must produce the
	 * same cache key. Before the sentinel fix, each instance embedded a
	 * per-instance random_bytes(18) value in the key, making them always differ.
	 *
	 * @covers ::get_cache_key
	 */
	public function test_cache_key_is_stable_across_query_instances() {
		$args = array(
			'number' => 10,
			'status' => 'complete',
		);

		$query_a = new Order_Query( $args );
		$query_b = new Order_Query( $args );

		$get_key = new \ReflectionMethod( Order_Query::class, 'get_cache_key' );
		$get_key->setAccessible( true );

		$key_a = $get_key->invoke( $query_a );
		$key_b = $get_key->invoke( $query_b );

		$this->assertSame( $key_a, $key_b );
	}

	/**
	 * A repeated identical query should hit the cache and fire no additional
	 * SQL. If the sentinel fix is absent the second call always misses the
	 * cache because it generates a different key.
	 *
	 * @covers ::get_items
	 */
	public function test_repeated_identical_query_does_not_fire_additional_sql() {
		global $wpdb;

		$args = array(
			'parent' => self::$order_id,
			'type'   => 'refund',
		);

		// Prime the cache.
		edd_get_orders( $args );

		$queries_before = $wpdb->num_queries;
		edd_get_orders( $args );
		$queries_after = $wpdb->num_queries;

		$this->assertSame( $queries_before, $queries_after );
	}
}
```

I've run the tests with the proposed changes and without and they confirm the fix. Happy to push up my tests branch and we could theoretically move forward on that and then add tests here before merging.