### PR TITLE
Add PHPUnit test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/.phpunit.result.cache

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Install the WordPress test suite and create a test database.
+#
+# Usage:
+#   bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]
+#
+# Example:
+#   bin/install-wp-tests.sh berlindb_tests root '' localhost latest
+
+if [ $# -lt 3 ]; then
+	echo "Usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+download() {
+	if [ $(which curl) ]; then
+		curl -s "$1" > "$2"
+	elif [ $(which wget) ]; then
+		wget -nv -O "$2" "$1"
+	fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 is not in the release archive
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http: //api.wordpress.org/core/version-check/1.7/
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*"' /tmp/wp-latest.json | sed 's/"version":"//;s/"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+	if [ -d $WP_CORE_DIR ]; then
+		return
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		if [ ! -d $TMPDIR/wordpress-trunk/tests/phpunit ]; then
+			svn export --quiet https://develop.svn.wordpress.org/trunk/ $TMPDIR/wordpress-trunk
+		fi
+		cd $TMPDIR/wordpress-trunk
+		if [ ! -e wp-config.php ]; then
+			cp wp-config-sample.php wp-config.php
+		fi
+	fi
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+		# https://wordpress.org/wordpress-3.7.zip
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.zip $TMPDIR/wordpress.zip
+	unzip -q $TMPDIR/wordpress.zip -d $TMPDIR
+	mv $TMPDIR/wordpress/* $WP_CORE_DIR
+}
+
+install_test_suite() {
+	# portable in-place argument for both BSD and GNU sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		mkdir -p $WP_TESTS_DIR
+
+		# Install test suite files from WordPress develop
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove leading slash from WordPress path so it works on Windows
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+}
+
+install_db() {
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]}
+	local DB_SOCK_OR_PORT=${PARTS[1]}
+	local EXTRA=""
+
+	if ! [ -z $DB_SOCK_OR_PORT ]; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		else
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		fi
+	elif ! [ -z $DB_HOSTNAME ]; then
+		EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -136,7 +136,7 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA --ssl=FALSE
 }
 
 install_wp

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -54,7 +54,7 @@ else
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
 
-set -ex
+set -e
 
 install_wp() {
 	if [ -d $WP_CORE_DIR ]; then

--- a/bin/run-tests-internal.sh
+++ b/bin/run-tests-internal.sh
@@ -2,7 +2,7 @@
 # Container-side test runner. Called by docker-compose-phpunit.yml.
 # Do not run this script directly on your host machine.
 
-set -ex
+set -e
 
 DB_HOST="${DB_HOST:-localhost}"
 DB_NAME="${DB_NAME:-berlindb_tests}"
@@ -14,9 +14,19 @@ WP_VERSION="${WP_VERSION:-latest}"
 # unzip+mv doesn't collide with the mkdir it creates first.
 export WP_CORE_DIR=/tmp/wp-core
 
-composer install --no-interaction --prefer-dist
+composer install --no-interaction --prefer-dist -q
 
 bin/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION"
+
+printf "\n"
+echo "🐘 PHP version:       $(php -v | head -n 1 | cut -d' ' -f2)"
+echo "🌍 WordPress version: $WP_VERSION"
+echo "🗄️  MariaDB version:   ${MARIADB_VERSION:-10.2}"
+if [[ "$PHPUNIT_ARGS" == *"--filter"* ]]; then
+	FILTER_VALUE=$(echo "$PHPUNIT_ARGS" | sed 's/.*--filter[= ]\([^ ]*\).*/\1/')
+	echo "🔍 Filter:            ${FILTER_VALUE}"
+fi
+printf "\n"
 
 if [[ -n "$PHPUNIT_ARGS" ]]; then
 	# shellcheck disable=SC2086

--- a/bin/run-tests-internal.sh
+++ b/bin/run-tests-internal.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Container-side test runner. Called by docker-compose-phpunit.yml.
+# Do not run this script directly on your host machine.
+
+set -ex
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_NAME="${DB_NAME:-berlindb_tests}"
+DB_USER="${DB_USER:-root}"
+DB_PASS="${DB_PASS:-}"
+WP_VERSION="${WP_VERSION:-latest}"
+
+# Use a path distinct from /tmp/wordpress so the install script's
+# unzip+mv doesn't collide with the mkdir it creates first.
+export WP_CORE_DIR=/tmp/wp-core
+
+composer install --no-interaction --prefer-dist
+
+bin/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION"
+
+if [[ -n "$PHPUNIT_ARGS" ]]; then
+	# shellcheck disable=SC2086
+	vendor/bin/phpunit $PHPUNIT_ARGS
+else
+	vendor/bin/phpunit
+fi

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run the BerlinDB PHPUnit test suite in Docker.
+#
+# Usage:
+#   bin/run-tests.sh [options] [-- phpunit-args...]
+#
+# Options:
+#   -p <version>   PHP version to use (default: 8.2)
+#   -w <version>   WordPress version to use (default: latest)
+#   -h             Show this help text
+#
+# Examples:
+#   bin/run-tests.sh
+#   bin/run-tests.sh -p 8.1
+#   bin/run-tests.sh -p 8.2 -w 6.4
+#   bin/run-tests.sh -- --filter ColumnTest
+#   bin/run-tests.sh -- --testdox
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+TEST_PHP_VERSION="8.2"
+WP_VERSION="latest"
+PHPUNIT_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-p)
+			TEST_PHP_VERSION="$2"
+			shift 2
+			;;
+		-w)
+			WP_VERSION="$2"
+			shift 2
+			;;
+		-h|--help)
+			sed -n '2,20p' "$0" | sed 's/^# \?//'
+			exit 0
+			;;
+		--)
+			shift
+			PHPUNIT_ARGS=("$@")
+			break
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			exit 1
+			;;
+	esac
+done
+
+export TEST_PHP_VERSION
+export WP_VERSION
+export COMPOSE_PROJECT_NAME="berlindb_tests_$(openssl rand -hex 4)"
+export PHPUNIT_ARGS="${PHPUNIT_ARGS[*]}"
+
+cd "$REPO_DIR"
+
+cleanup() {
+	docker compose -f docker-compose-phpunit.yml down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+docker compose -f docker-compose-phpunit.yml build php
+docker compose -f docker-compose-phpunit.yml run --rm php

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -7,12 +7,14 @@
 # Options:
 #   -p <version>   PHP version to use (default: 8.2)
 #   -w <version>   WordPress version to use (default: latest)
+#   -d <version>   MariaDB version to use (default: 10.2)
 #   -h             Show this help text
 #
 # Examples:
 #   bin/run-tests.sh
 #   bin/run-tests.sh -p 8.1
 #   bin/run-tests.sh -p 8.2 -w 6.4
+#   bin/run-tests.sh -d 11.8
 #   bin/run-tests.sh -- --filter ColumnTest
 #   bin/run-tests.sh -- --testdox
 
@@ -23,6 +25,7 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 TEST_PHP_VERSION="8.2"
 WP_VERSION="latest"
+MARIADB_VERSION="10.2"
 PHPUNIT_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -35,8 +38,12 @@ while [[ $# -gt 0 ]]; do
 			WP_VERSION="$2"
 			shift 2
 			;;
+		-d)
+			MARIADB_VERSION="$2"
+			shift 2
+			;;
 		-h|--help)
-			sed -n '2,20p' "$0" | sed 's/^# \?//'
+			sed -n '2,21p' "$0" | sed 's/^# \?//'
 			exit 0
 			;;
 		--)
@@ -53,6 +60,7 @@ done
 
 export TEST_PHP_VERSION
 export WP_VERSION
+export MARIADB_VERSION
 export COMPOSE_PROJECT_NAME="berlindb_tests_$(openssl rand -hex 4)"
 export PHPUNIT_ARGS="${PHPUNIT_ARGS[*]}"
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "berlindb/core",
   "description": "A collection of PHP classes and functions that aims to provide an ORM-like experience and interface to WordPress database tables.",
+  "version": "2.1.0",
   "type": "library",
   "license": "MIT",
   "autoload": {
@@ -10,7 +11,15 @@
   },
   "require-dev": {
     "szepeviktor/phpstan-wordpress": "^0.7.7",
-    "phpstan/extension-installer": "^1.1"
+    "phpstan/extension-installer": "^1.1",
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^1.1.0",
+    "yoast/wp-test-utils": "^1.2"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "BerlinDB\\Tests\\": "tests/"
+    }
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,594 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff2a6025b5680b5b700a3016c03a5341",
+    "content-hash": "3661460af3d27c4a526dcf74137d6ac9",
     "packages": [],
     "packages-dev": [
         {
-            "name": "php-stubs/wordpress-stubs",
-            "version": "v5.9.3",
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee"
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/18d56875e5078a50b8ea4bc4b20b735ca61edeee",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
                 "shasum": ""
             },
-            "replace": {
-                "giacocorsiglia/wordpress-stubs": "*"
+            "require": {
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "nikic/php-parser": "< 4.12.0",
-                "php": "~7.3 || ~8.0",
-                "php-stubs/generator": "^0.8.1",
-                "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.2"
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "~1.3.6 || ~1.4.4 || ~1.5.1 || ^1.6.10",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.49 || ^9.6.30"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2026-02-05T09:22:14+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v5.9.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "06c51c4863659ea9e9f4c2a23293728a677cb059"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/06c51c4863659ea9e9f4c2a23293728a677cb059",
+                "reference": "06c51c4863659ea9e9f4c2a23293728a677cb059",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "5.3",
+                "phpstan/phpstan": "^1.10.49",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
             "type": "library",
@@ -50,9 +608,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.9"
             },
-            "time": "2022-04-06T15:33:59+00:00"
+            "time": "2024-04-14T17:16:00+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -101,16 +659,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.99",
+            "version": "0.12.100",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
+                "reference": "48236ddf823547081b2b153d1cd2994b784328c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/48236ddf823547081b2b153d1cd2994b784328c3",
+                "reference": "48236ddf823547081b2b153d1cd2994b784328c3",
                 "shasum": ""
             },
             "require": {
@@ -141,7 +699,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.100"
             },
             "funding": [
                 {
@@ -153,41 +711,1475 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-12T20:09:55+00:00"
+            "time": "2022-11-01T09:52:08+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.26.0",
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
                 },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -224,7 +2216,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -236,11 +2228,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
@@ -305,14 +2301,199 @@
                 }
             ],
             "time": "2021-07-14T09:19:15+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T04:54:36+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "e1c316f10ff892fff36116349b59ee5a00174ca3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/e1c316f10ff892fff36116349b59ee5a00174ca3",
+                "reference": "e1c316f10ff892fff36116349b59ee5a00174ca3",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.7.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^1.1.5"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "exclude-from-classmap": [
+                    "/src/WPIntegration/TestCase.php",
+                    "/src/WPIntegration/TestCaseNoPolyfills.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "testing",
+                "unit-testing",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/wp-test-utils/issues",
+                "security": "https://github.com/Yoast/wp-test-utils/security/policy",
+                "source": "https://github.com/Yoast/wp-test-utils"
+            },
+            "time": "2026-02-05T18:06:16+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -15,16 +15,17 @@ services:
       DB_HOST: mysql
       DB_NAME: berlindb_tests
       DB_USER: root
-      DB_PASS: ""
+      DB_PASS: "wordpress"
       WP_VERSION: "${WP_VERSION:-latest}"
     command: bin/run-tests-internal.sh
 
   mysql:
     image: mariadb:${MARIADB_VERSION:-10.2}
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_PASSWORD: "wordpress"
+      MARIADB_ROOT_PASSWORD: "wordpress"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized 2>/dev/null || mysqladmin ping -h 127.0.0.1 -pwordpress --silent"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -20,7 +20,7 @@ services:
     command: bin/run-tests-internal.sh
 
   mysql:
-    image: mariadb:10.2
+    image: mariadb:${MARIADB_VERSION:-10.2}
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     healthcheck:

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -25,7 +25,7 @@ services:
       MYSQL_ROOT_PASSWORD: "wordpress"
       MARIADB_ROOT_PASSWORD: "wordpress"
     healthcheck:
-      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized 2>/dev/null || mysqladmin ping -h 127.0.0.1 -pwordpress --silent"]
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized 2>/dev/null || mysqladmin ping -h 127.0.0.1 -pwordpress --silent --ssl=FALSE"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -1,0 +1,30 @@
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.test
+      args:
+        PHP_VERSION: "${TEST_PHP_VERSION:-8.2}"
+    volumes:
+      - .:/app
+    working_dir: /app
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      DB_HOST: mysql
+      DB_NAME: berlindb_tests
+      DB_USER: root
+      DB_PASS: ""
+      WP_VERSION: "${WP_VERSION:-latest}"
+    command: bin/run-tests-internal.sh
+
+  mysql:
+    image: mariadb:10.2
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,22 @@
+ARG PHP_VERSION=8.2
+FROM php:${PHP_VERSION}-cli
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-mysql-client \
+    git \
+    libonig-dev \
+    libxml2-dev \
+    subversion \
+    unzip \
+    && docker-php-ext-install \
+        dom \
+        mbstring \
+        mysqli \
+        pdo_mysql \
+        xml \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+>
+    <testsuites>
+        <testsuite name="BerlinDB Integration Tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="false">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2570,8 +2570,8 @@ class Query extends Base {
 				return false;
 			}
 
-			// Update item cache(s)
-			$this->update_item_cache( $retval );
+			// Update item cache(s) — read path, do not bump last_changed.
+			$this->update_item_cache( $retval, false );
 		}
 
 		// Reduce the item
@@ -3539,8 +3539,8 @@ class Query extends Base {
 				$prepare = sprintf( $query, $ids );
 				$results = $db->get_results( $prepare );
 
-				// Update item cache(s)
-				$this->update_item_cache( $results );
+				// Update item cache(s) — read path, do not bump last_changed.
+				$this->update_item_cache( $results, false );
 			}
 		}
 
@@ -3580,7 +3580,7 @@ class Query extends Base {
 	 * @param int|object|array $items Primary ID if int. Row if object. Array
 	 *                                of objects if array.
 	 */
-	private function update_item_cache( $items = array() ) {
+	private function update_item_cache( $items = array(), $bump_last_changed = true ) {
 
 		// Maybe query for single item
 		if ( is_scalar( $items ) ) {
@@ -3624,8 +3624,11 @@ class Query extends Base {
 			}
 		}
 
-		// Update last changed
-		$this->update_last_changed_cache();
+		// Only bump last_changed for mutations; read-path warming must not
+		// invalidate the list cache that was just stored.
+		if ( $bump_last_changed ) {
+			$this->update_last_changed_cache();
+		}
 	}
 
 	/**

--- a/src/Database/Table.php
+++ b/src/Database/Table.php
@@ -1161,8 +1161,8 @@ abstract class Table extends Base {
 	 */
 	private function get_db_version() {
 		$this->db_version = $this->is_global()
-			? get_network_option( get_main_network_id(), $this->db_version_key, 1 )
-			:         get_option(                        $this->db_version_key, 1 );
+			? get_network_option( get_main_network_id(), $this->db_version_key, '' )
+			:         get_option(                        $this->db_version_key, '' );
 	}
 
 	/**

--- a/src/Database/Table.php
+++ b/src/Database/Table.php
@@ -274,7 +274,7 @@ abstract class Table extends Base {
 		$this->get_db_version();
 
 		// Is this database table up to date?
-		$is_current = version_compare( $this->db_version, $version, '>=' );
+		$is_current = version_compare( (string) $this->db_version, (string) $version, '>=' );
 
 		// Return false if current, true if out of date
 		return ( true === $is_current )
@@ -310,10 +310,10 @@ abstract class Table extends Base {
 	 *
 	 * @return string
 	 */
-	public function get_version() {
+	public function get_version(): string {
 		$this->get_db_version();
 
-		return $this->db_version;
+		return (string) $this->db_version;
 	}
 
 	/**
@@ -978,7 +978,7 @@ abstract class Table extends Base {
 
 		// Loop through all upgrades, and pick out the ones that need doing
 		foreach ( $this->upgrades as $version => $callback ) {
-			if ( true === version_compare( $version, $this->db_version, '>' ) ) {
+			if ( true === version_compare( (string) $version, (string) $this->db_version, '>' ) ) {
 				$upgrades[ $version ] = $callback;
 			}
 		}

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Column class tests.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Database\Column;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for BerlinDB\Database\Column.
+ *
+ * Column is a pure data container; these tests do not require a database
+ * connection, only a WordPress bootstrap for functions like wp_parse_args
+ * and remove_accents.
+ *
+ * @since 2.1.0
+ */
+class ColumnTest extends TestCase {
+
+	// Default property values
+
+	public function test_default_name_is_empty_string() {
+		$column = new Column();
+		$this->assertSame( '', $column->name );
+	}
+
+	public function test_default_type_is_empty_string() {
+		$column = new Column();
+		$this->assertSame( '', $column->type );
+	}
+
+	public function test_default_unsigned_is_true() {
+		$column = new Column();
+		$this->assertTrue( $column->unsigned );
+	}
+
+	public function test_default_allow_null_is_false() {
+		$column = new Column();
+		$this->assertFalse( $column->allow_null );
+	}
+
+	public function test_default_primary_is_false() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertFalse( $column->primary );
+	}
+
+	// Type detection
+
+	public function test_is_numeric_returns_true_for_bigint() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertTrue( $column->is_numeric() );
+	}
+
+	public function test_is_int_returns_true_for_bigint() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertTrue( $column->is_int() );
+	}
+
+	public function test_is_text_returns_false_for_bigint() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertFalse( $column->is_text() );
+	}
+
+	public function test_is_text_returns_true_for_varchar() {
+		$column = new Column( array( 'name' => 'title', 'type' => 'varchar', 'length' => '255' ) );
+		$this->assertTrue( $column->is_text() );
+	}
+
+	public function test_is_numeric_returns_false_for_varchar() {
+		$column = new Column( array( 'name' => 'title', 'type' => 'varchar', 'length' => '255' ) );
+		$this->assertFalse( $column->is_numeric() );
+	}
+
+	public function test_is_date_time_returns_true_for_datetime() {
+		$column = new Column( array( 'name' => 'created', 'type' => 'datetime' ) );
+		$this->assertTrue( $column->is_date_time() );
+	}
+
+	public function test_is_date_time_returns_false_for_varchar() {
+		$column = new Column( array( 'name' => 'title', 'type' => 'varchar', 'length' => '255' ) );
+		$this->assertFalse( $column->is_date_time() );
+	}
+
+	// special_args(): primary → cache_key
+
+	public function test_primary_true_forces_cache_key_true() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint', 'primary' => true ) );
+		$this->assertTrue( $column->primary );
+		$this->assertTrue( $column->cache_key );
+	}
+
+	// special_args(): uuid
+
+	public function test_uuid_true_forces_name_to_uuid() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertSame( 'uuid', $column->name );
+	}
+
+	public function test_uuid_true_forces_type_to_varchar() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertSame( 'VARCHAR', $column->type );
+	}
+
+	public function test_uuid_true_forces_length_to_100() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertSame( 100, $column->length );
+	}
+
+	public function test_uuid_true_disables_in() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertFalse( $column->in );
+	}
+
+	public function test_uuid_true_disables_not_in() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertFalse( $column->not_in );
+	}
+
+	public function test_uuid_true_disables_searchable() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertFalse( $column->searchable );
+	}
+
+	public function test_uuid_true_disables_sortable() {
+		$column = new Column( array( 'uuid' => true ) );
+		$this->assertFalse( $column->sortable );
+	}
+
+	// special_args(): SERIAL extra
+
+	public function test_serial_extra_forces_bigint_type() {
+		$column = new Column( array( 'extra' => 'SERIAL' ) );
+		$this->assertSame( 'BIGINT', $column->type );
+	}
+
+	public function test_serial_extra_forces_primary_true() {
+		$column = new Column( array( 'extra' => 'SERIAL' ) );
+		$this->assertTrue( $column->primary );
+	}
+
+	public function test_serial_extra_forces_auto_increment() {
+		$column = new Column( array( 'extra' => 'SERIAL' ) );
+		$this->assertSame( 'AUTO_INCREMENT', $column->extra );
+	}
+
+	public function test_serial_extra_forces_unsigned_true() {
+		$column = new Column( array( 'extra' => 'SERIAL' ) );
+		$this->assertTrue( $column->unsigned );
+	}
+
+	// get_create_string()
+
+	public function test_get_create_string_for_primary_column_contains_name() {
+		$column = new Column( array(
+			'name'    => 'id',
+			'type'    => 'bigint',
+			'length'  => '20',
+			'primary' => true,
+			'extra'   => 'auto_increment',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( '`id`', $sql );
+	}
+
+	public function test_get_create_string_for_primary_column_contains_type() {
+		$column = new Column( array(
+			'name'    => 'id',
+			'type'    => 'bigint',
+			'length'  => '20',
+			'primary' => true,
+			'extra'   => 'auto_increment',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'bigint(20)', $sql );
+	}
+
+	public function test_get_create_string_for_primary_column_contains_unsigned() {
+		$column = new Column( array(
+			'name'     => 'id',
+			'type'     => 'bigint',
+			'length'   => '20',
+			'unsigned' => true,
+			'primary'  => true,
+			'extra'    => 'auto_increment',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'unsigned', $sql );
+	}
+
+	public function test_get_create_string_for_primary_column_contains_auto_increment() {
+		$column = new Column( array(
+			'name'   => 'id',
+			'type'   => 'bigint',
+			'length' => '20',
+			'extra'  => 'auto_increment',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'AUTO_INCREMENT', $sql );
+	}
+
+	public function test_get_create_string_for_varchar_column_contains_length() {
+		$column = new Column( array(
+			'name'    => 'title',
+			'type'    => 'varchar',
+			'length'  => '200',
+			'default' => '',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'varchar(200)', $sql );
+	}
+
+	public function test_get_create_string_for_varchar_column_contains_not_null() {
+		$column = new Column( array(
+			'name'       => 'title',
+			'type'       => 'varchar',
+			'length'     => '200',
+			'allow_null' => false,
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'not null', $sql );
+	}
+
+	public function test_get_create_string_for_datetime_column_contains_type() {
+		$column = new Column( array(
+			'name' => 'created_at',
+			'type' => 'datetime',
+		) );
+		$sql = $column->get_create_string();
+		$this->assertStringContainsString( 'datetime', $sql );
+	}
+
+	// Validation helpers
+
+	public function test_validate_uuid_generates_urn_prefix_for_empty_value() {
+		$column = new Column( array( 'uuid' => true ) );
+		$result = $column->validate_uuid( '' );
+		$this->assertStringStartsWith( 'urn:uuid:', $result );
+	}
+
+	public function test_validate_uuid_preserves_existing_urn_uuid() {
+		$column   = new Column( array( 'uuid' => true ) );
+		$existing = 'urn:uuid:550e8400-e29b-41d4-a716-446655440000';
+		$result   = $column->validate_uuid( $existing );
+		$this->assertSame( $existing, $result );
+	}
+
+	public function test_validate_int_coerces_string_to_int() {
+		$column = new Column( array( 'name' => 'count', 'type' => 'bigint' ) );
+		$result = $column->validate_int( '42' );
+		$this->assertSame( 42, $result );
+	}
+
+	public function test_validate_datetime_returns_valid_datetime_string() {
+		$column = new Column( array( 'name' => 'created', 'type' => 'datetime' ) );
+		$result = $column->validate_datetime( '2024-01-15 10:30:00' );
+		$this->assertSame( '2024-01-15 10:30:00', $result );
+	}
+
+	public function test_validate_datetime_returns_empty_string_for_empty_value() {
+		// validate_datetime() returns $this->default for empty values, so the
+		// column must have the zero-date default for this assertion to hold.
+		$column = new Column( array( 'name' => 'created', 'type' => 'datetime' ) );
+		$result = $column->validate_datetime( '' );
+		$this->assertEmpty( $result );
+	}
+
+	// Base::__get() magic getter
+
+	public function test_magic_getter_accesses_protected_sortable_property() {
+		$column = new Column( array( 'name' => 'title', 'type' => 'varchar', 'sortable' => true ) );
+		$this->assertTrue( $column->sortable );
+	}
+
+	public function test_magic_getter_returns_null_for_nonexistent_property() {
+		$column = new Column();
+		$this->assertNull( $column->nonexistent_property_xyz );
+	}
+
+	// Capabilities
+
+	public function test_caps_defaults_contain_all_four_operations() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertArrayHasKey( 'select', $column->caps );
+		$this->assertArrayHasKey( 'insert', $column->caps );
+		$this->assertArrayHasKey( 'update', $column->caps );
+		$this->assertArrayHasKey( 'delete', $column->caps );
+	}
+
+	public function test_caps_default_to_exist_capability() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint' ) );
+		$this->assertSame( 'exist', $column->caps['insert'] );
+	}
+
+	// to_array()
+
+	public function test_to_array_includes_name_key() {
+		$column = new Column( array( 'name' => 'status', 'type' => 'varchar' ) );
+		$arr    = $column->to_array();
+		$this->assertArrayHasKey( 'name', $arr );
+		$this->assertSame( 'status', $arr['name'] );
+	}
+
+	public function test_to_array_includes_type_key() {
+		$column = new Column( array( 'name' => 'status', 'type' => 'VARCHAR' ) );
+		$arr    = $column->to_array();
+		$this->assertArrayHasKey( 'type', $arr );
+	}
+
+	public function test_to_array_includes_primary_key() {
+		$column = new Column( array( 'name' => 'id', 'type' => 'bigint', 'primary' => true ) );
+		$arr    = $column->to_array();
+		$this->assertArrayHasKey( 'primary', $arr );
+		$this->assertTrue( $arr['primary'] );
+	}
+}

--- a/tests/Fixtures/TestQuery.php
+++ b/tests/Fixtures/TestQuery.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test Query fixture for BerlinDB integration tests.
+ *
+ * @package     BerlinDB\Tests\Fixtures
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests\Fixtures;
+
+use BerlinDB\Database\Query;
+
+/**
+ * Query implementation for the test_widgets table.
+ *
+ * $table_name must match the $name set in TestTable (= the value registered
+ * on $wpdb after TestTable is constructed). Query resolves the full table name
+ * via get_db()->{$this->table_name}.
+ *
+ * @since 2.1.0
+ */
+class TestQuery extends Query {
+
+	/** @var string */
+	protected $table_name = 'berlindb_test_widgets';
+
+	/** @var string */
+	protected $table_alias = 'tw';
+
+	/** @var string */
+	protected $table_schema = TestSchema::class;
+
+	/** @var string */
+	protected $item_name = 'widget';
+
+	/** @var string */
+	protected $item_name_plural = 'widgets';
+
+	/** @var string */
+	protected $item_shape = TestRow::class;
+
+	/** @var string */
+	protected $cache_group = 'berlindb-test-widgets';
+}

--- a/tests/Fixtures/TestRow.php
+++ b/tests/Fixtures/TestRow.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Test Row fixture for BerlinDB integration tests.
+ *
+ * @package     BerlinDB\Tests\Fixtures
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests\Fixtures;
+
+use BerlinDB\Database\Row;
+
+/**
+ * Typed row wrapper for test_widgets table rows.
+ *
+ * @since 2.1.0
+ */
+class TestRow extends Row {
+
+	/** @var int */
+	public $id = 0;
+
+	/** @var string */
+	public $name = '';
+
+	/** @var string */
+	public $status = 'active';
+
+	/** @var int */
+	public $priority = 0;
+
+	/** @var string */
+	public $date_created = '';
+
+	/** @var string */
+	public $date_modified = '';
+
+	/** @var string */
+	public $uuid = '';
+}

--- a/tests/Fixtures/TestSchema.php
+++ b/tests/Fixtures/TestSchema.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Test Schema fixture for BerlinDB integration tests.
+ *
+ * @package     BerlinDB\Tests\Fixtures
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests\Fixtures;
+
+use BerlinDB\Database\Schema;
+
+/**
+ * Minimal Schema fixture covering all common column flags.
+ *
+ * @since 2.1.0
+ */
+class TestSchema extends Schema {
+
+	/**
+	 * Column definitions.
+	 *
+	 * Declared public to allow direct access in tests.
+	 *
+	 * @since 2.1.0
+	 * @var array
+	 */
+	public $columns = array(
+
+		// Primary key.
+		array(
+			'name'     => 'id',
+			'type'     => 'bigint',
+			'length'   => '20',
+			'unsigned' => true,
+			'extra'    => 'auto_increment',
+			'primary'  => true,
+			'sortable' => true,
+		),
+
+		// Searchable, sortable varchar.
+		array(
+			'name'       => 'name',
+			'type'       => 'varchar',
+			'length'     => '200',
+			'default'    => '',
+			'searchable' => true,
+			'sortable'   => true,
+		),
+
+		// Status with transition and dedicated cache key.
+		array(
+			'name'       => 'status',
+			'type'       => 'varchar',
+			'length'     => '20',
+			'default'    => 'active',
+			'cache_key'  => true,
+			'transition' => true,
+			'sortable'   => true,
+			'in'         => true,
+			'not_in'     => true,
+		),
+
+		// Integer with in/not_in support.
+		array(
+			'name'     => 'priority',
+			'type'     => 'bigint',
+			'length'   => '20',
+			'unsigned' => true,
+			'default'  => '0',
+			'sortable' => true,
+			'in'       => true,
+			'not_in'   => true,
+		),
+
+		// Auto-set creation timestamp.
+		array(
+			'name'       => 'date_created',
+			'type'       => 'datetime',
+			'default'    => '',
+			'created'    => true,
+			'date_query' => true,
+			'sortable'   => true,
+		),
+
+		// Auto-updated modification timestamp.
+		array(
+			'name'       => 'date_modified',
+			'type'       => 'datetime',
+			'default'    => '',
+			'modified'   => true,
+			'date_query' => true,
+			'sortable'   => true,
+		),
+
+		// UUID column — exercises special_args() UUID branch.
+		array(
+			'uuid' => true,
+		),
+	);
+}

--- a/tests/Fixtures/TestTable.php
+++ b/tests/Fixtures/TestTable.php
@@ -56,7 +56,7 @@ final class TestTable extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202604230.1' => '__202604230',
+		'202604231' => '__202604231',
 	);
 
 	/**
@@ -85,7 +85,7 @@ final class TestTable extends Table {
 	 * @since 2.1.0
 	 * @return bool
 	 */
-	protected function __202604230() {
+	protected function __202604231() {
 		if ( ! $this->column_exists( 'notes' ) ) {
 			$result = $this->get_db()->query(
 				"ALTER TABLE {$this->table_name} ADD COLUMN notes longtext NOT NULL default ''"
@@ -103,5 +103,15 @@ final class TestTable extends Table {
 	 */
 	public function get_db_version_key() {
 		return $this->db_version_key;
+	}
+
+	/**
+	 * Expose the schema version constant for test assertions.
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	public function get_schema_version(): string {
+		return $this->version;
 	}
 }

--- a/tests/Fixtures/TestTable.php
+++ b/tests/Fixtures/TestTable.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Test Table fixture for BerlinDB integration tests.
+ *
+ * @package     BerlinDB\Tests\Fixtures
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests\Fixtures;
+
+use BerlinDB\Database\Table;
+
+/**
+ * Concrete Table implementation for test_widgets table.
+ *
+ * Using a raw SQL string in set_schema() is the standard convention for Table.
+ * The Schema object is used by the Query, not the Table.
+ *
+ * The $upgrades array registers a v2 upgrade callback that adds a
+ * 'notes' column, allowing tests to verify the upgrade flow.
+ *
+ * @since 2.1.0
+ */
+final class TestTable extends Table {
+
+	/**
+	 * Table name (without wpdb prefix).
+	 *
+	 * @since 2.1.0
+	 * @var string
+	 */
+	protected $name = 'berlindb_test_widgets';
+
+	/**
+	 * Current table version.
+	 *
+	 * Uses EDD-style date-based version numbers (YYYYMMDDN as string).
+	 * Must be a string because Table.php declares strict_types=1 and
+	 * version_compare() requires string arguments.
+	 *
+	 * @since 2.1.0
+	 * @var string
+	 */
+	protected $version = '202604230';
+
+	/**
+	 * Upgrade callbacks keyed by the version they upgrade to.
+	 *
+	 * The dot suffix prevents PHP from coercing the key to int. Pure-numeric
+	 * string keys (e.g. '202604231') become int at runtime, and Table.php's
+	 * declare(strict_types=1) then causes a TypeError in version_compare().
+	 *
+	 * @since 2.1.0
+	 * @var array
+	 */
+	protected $upgrades = array(
+		'202604230.1' => '__202604230',
+	);
+
+	/**
+	 * Set the table schema as a raw SQL string.
+	 *
+	 * @since 2.1.0
+	 */
+	protected function set_schema() {
+		$this->schema =
+			'id bigint(20) unsigned NOT NULL auto_increment,' .
+			"name varchar(200) NOT NULL default ''," .
+			"status varchar(20) NOT NULL default 'active'," .
+			'priority bigint(20) unsigned NOT NULL default 0,' .
+			'date_created datetime NOT NULL default CURRENT_TIMESTAMP,' .
+			'date_modified datetime NOT NULL default CURRENT_TIMESTAMP,' .
+			"uuid varchar(100) NOT NULL default ''," .
+			'PRIMARY KEY (id),' .
+			'KEY status (status)';
+	}
+
+	/**
+	 * Upgrade to version 2: add a notes column.
+	 *
+	 * Used by test_upgrade_runs_callback_and_adds_column().
+	 *
+	 * @since 2.1.0
+	 * @return bool
+	 */
+	protected function __202604230() {
+		if ( ! $this->column_exists( 'notes' ) ) {
+			$result = $this->get_db()->query(
+				"ALTER TABLE {$this->table_name} ADD COLUMN notes longtext NOT NULL default ''"
+			);
+			return $this->is_success( $result );
+		}
+		return true;
+	}
+
+	/**
+	 * Expose the db_version_key for test manipulation.
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	public function get_db_version_key() {
+		return $this->db_version_key;
+	}
+}

--- a/tests/QueryCacheTest.php
+++ b/tests/QueryCacheTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Query cache key and result-caching tests.
+ *
+ * Verifies that the sentinel-stripping fix in get_cache_key() allows
+ * BerlinDB's query-result cache to work correctly across Query instances.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Tests\Fixtures\TestQuery;
+use BerlinDB\Tests\Fixtures\TestTable;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for Query cache key stability and query-result caching.
+ *
+ * @since 2.1.0
+ */
+class QueryCacheTest extends TestCase {
+
+	/** @var TestTable */
+	private static $table;
+
+	/** @var TestQuery */
+	private static $query;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$table = new TestTable();
+		if ( ! self::$table->exists() ) {
+			self::$table->install();
+		}
+		self::$query = new TestQuery();
+	}
+
+	public static function tearDownAfterClass(): void {
+		self::$table->uninstall();
+		parent::tearDownAfterClass();
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// parent::setUp() resets the current user to 0 via clean_up_global_scope().
+		// Re-set here so add_item() passes Query::reduce_item() capability checks.
+		wp_set_current_user( 1 );
+
+		self::$table->delete_all();
+		self::$query->add_item( array( 'name' => 'Cache Widget', 'status' => 'active' ) );
+		wp_cache_flush();
+	}
+
+	/**
+	 * Two separate Query instances with identical arguments must produce the
+	 * same cache key. Before the sentinel fix, each instance embedded a
+	 * per-instance random_bytes(18) value in the key, making them always differ.
+	 */
+	public function test_cache_key_is_stable_across_query_instances() {
+		$args = array(
+			'number' => 10,
+			'status' => 'active',
+		);
+
+		$query_a = new TestQuery( $args );
+		$query_b = new TestQuery( $args );
+
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$get_key->setAccessible( true );
+
+		$key_a = $get_key->invoke( $query_a );
+		$key_b = $get_key->invoke( $query_b );
+
+		$this->assertSame( $key_a, $key_b );
+	}
+
+	/**
+	 * A repeated identical query should hit the cache and fire no additional
+	 * SQL. If the sentinel fix is absent the second call always misses the
+	 * cache because it generates a different key.
+	 */
+	public function test_repeated_identical_query_does_not_fire_additional_sql() {
+		global $wpdb;
+
+		$args = array(
+			'number' => 10,
+			'status' => 'active',
+		);
+
+		// Prime the cache.
+		self::$query->query( $args );
+
+		$queries_before = $wpdb->num_queries;
+		self::$query->query( $args );
+		$queries_after = $wpdb->num_queries;
+
+		$this->assertSame( $queries_before, $queries_after );
+	}
+}

--- a/tests/QueryCrudTest.php
+++ b/tests/QueryCrudTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Query CRUD operation tests.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Tests\Fixtures\TestQuery;
+use BerlinDB\Tests\Fixtures\TestRow;
+use BerlinDB\Tests\Fixtures\TestTable;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for Query CRUD methods: add_item, get_item, get_item_by,
+ * update_item, delete_item, copy_item.
+ *
+ * wp_set_current_user(1) is required because Query::reduce_item() strips
+ * columns where current_user_can( $caps[$method] ) returns false. The
+ * default cap is 'exist', which requires a logged-in user.
+ *
+ * @since 2.1.0
+ */
+class QueryCrudTest extends TestCase {
+
+	/** @var TestTable */
+	private static $table;
+
+	/** @var TestQuery */
+	private static $query;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$table = new TestTable();
+		if ( ! self::$table->exists() ) {
+			self::$table->install();
+		}
+		self::$query = new TestQuery();
+	}
+
+	public static function tearDownAfterClass(): void {
+		self::$table->uninstall();
+		parent::tearDownAfterClass();
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// parent::setUp() resets the current user to 0 via clean_up_global_scope().
+		// Re-set here so Query::reduce_item() passes capability checks.
+		wp_set_current_user( 1 );
+
+		self::$table->delete_all();
+		wp_cache_flush();
+	}
+
+	// add_item()
+
+	public function test_add_item_returns_positive_integer_id() {
+		$id = self::$query->add_item( array( 'name' => 'Widget A', 'status' => 'active' ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+	}
+
+	public function test_add_item_with_empty_array_returns_id_via_autofill() {
+		// BerlinDB auto-fills uuid, date_created, and date_modified even when
+		// no explicit data is provided, so the insert succeeds.
+		$result = self::$query->add_item( array() );
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function test_add_item_sets_date_created_automatically() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget A' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertNotEmpty( $item->date_created );
+		$this->assertNotSame( '0000-00-00 00:00:00', $item->date_created );
+	}
+
+	public function test_add_item_sets_date_modified_automatically() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget A' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertNotEmpty( $item->date_modified );
+		$this->assertNotSame( '0000-00-00 00:00:00', $item->date_modified );
+	}
+
+	public function test_add_item_sets_uuid_automatically() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget A' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertStringStartsWith( 'urn:uuid:', $item->uuid );
+	}
+
+	// get_item()
+
+	public function test_get_item_returns_test_row_instance() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget A' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertInstanceOf( TestRow::class, $item );
+	}
+
+	public function test_get_item_returns_correct_name() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget Unique' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertSame( 'Widget Unique', $item->name );
+	}
+
+	public function test_get_item_returns_correct_status() {
+		$id   = self::$query->add_item( array( 'name' => 'Widget A', 'status' => 'inactive' ) );
+		$item = self::$query->get_item( $id );
+		$this->assertSame( 'inactive', $item->status );
+	}
+
+	public function test_get_item_returns_false_for_nonexistent_id() {
+		$result = self::$query->get_item( 999999 );
+		$this->assertFalse( $result );
+	}
+
+	// get_item_by()
+
+	public function test_get_item_by_returns_row_for_existing_status() {
+		self::$query->add_item( array( 'name' => 'Widget A', 'status' => 'pending' ) );
+		$item = self::$query->get_item_by( 'status', 'pending' );
+		$this->assertInstanceOf( TestRow::class, $item );
+	}
+
+	public function test_get_item_by_returns_correct_item() {
+		$id = self::$query->add_item( array( 'name' => 'Needle Widget', 'status' => 'active' ) );
+		$item = self::$query->get_item_by( 'name', 'Needle Widget' );
+		$this->assertSame( $id, (int) $item->id );
+	}
+
+	public function test_get_item_by_returns_false_for_nonexistent_value() {
+		$result = self::$query->get_item_by( 'name', 'Absolutely Nonexistent XYZ' );
+		$this->assertFalse( $result );
+	}
+
+	// update_item()
+
+	public function test_update_item_modifies_name() {
+		$id = self::$query->add_item( array( 'name' => 'Original' ) );
+		self::$query->update_item( $id, array( 'name' => 'Updated' ) );
+
+		wp_cache_flush();
+		$item = self::$query->get_item( $id );
+		$this->assertSame( 'Updated', $item->name );
+	}
+
+	public function test_update_item_modifies_status() {
+		$id = self::$query->add_item( array( 'name' => 'Widget A', 'status' => 'active' ) );
+		self::$query->update_item( $id, array( 'status' => 'inactive' ) );
+
+		wp_cache_flush();
+		$item = self::$query->get_item( $id );
+		$this->assertSame( 'inactive', $item->status );
+	}
+
+	public function test_update_item_returns_false_for_nonexistent_id() {
+		$result = self::$query->update_item( 999999, array( 'name' => 'Ghost' ) );
+		$this->assertFalse( $result );
+	}
+
+	public function test_update_item_returns_false_for_empty_data() {
+		$id     = self::$query->add_item( array( 'name' => 'Widget A' ) );
+		$result = self::$query->update_item( $id, array() );
+		$this->assertFalse( $result );
+	}
+
+	// delete_item()
+
+	public function test_delete_item_removes_the_row() {
+		$id = self::$query->add_item( array( 'name' => 'Doomed Widget' ) );
+		self::$query->delete_item( $id );
+
+		wp_cache_flush();
+		$this->assertFalse( self::$query->get_item( $id ) );
+	}
+
+	public function test_delete_item_reduces_count_to_zero() {
+		$id = self::$query->add_item( array( 'name' => 'Only Widget' ) );
+		self::$query->delete_item( $id );
+
+		$this->assertSame( 0, self::$table->count() );
+	}
+
+	public function test_delete_item_returns_false_for_nonexistent_id() {
+		$result = self::$query->delete_item( 999999 );
+		$this->assertFalse( $result );
+	}
+
+	// copy_item()
+
+	public function test_copy_item_creates_a_new_row() {
+		$id     = self::$query->add_item( array( 'name' => 'Original Widget' ) );
+		$new_id = self::$query->copy_item( $id );
+
+		$this->assertIsInt( $new_id );
+		$this->assertNotSame( $id, $new_id );
+		$this->assertSame( 2, self::$table->count() );
+	}
+
+	public function test_copy_item_preserves_name_by_default() {
+		$id     = self::$query->add_item( array( 'name' => 'Original Widget' ) );
+		$new_id = self::$query->copy_item( $id );
+
+		wp_cache_flush();
+		$copy = self::$query->get_item( $new_id );
+		$this->assertSame( 'Original Widget', $copy->name );
+	}
+
+	public function test_copy_item_can_override_data() {
+		$id     = self::$query->add_item( array( 'name' => 'Original Widget', 'status' => 'active' ) );
+		$new_id = self::$query->copy_item( $id, array( 'status' => 'inactive' ) );
+
+		wp_cache_flush();
+		$copy = self::$query->get_item( $new_id );
+		$this->assertSame( 'inactive', $copy->status );
+	}
+}

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Query filtering and sorting tests.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Tests\Fixtures\TestQuery;
+use BerlinDB\Tests\Fixtures\TestRow;
+use BerlinDB\Tests\Fixtures\TestTable;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for Query::query() filtering, ordering, pagination, and count mode.
+ *
+ * Five fixture rows are created once for the whole class:
+ *  - Alpha Widget    | active   | priority 10
+ *  - Beta Widget     | active   | priority 20
+ *  - Gamma Gadget    | inactive | priority 30
+ *  - Delta Gadget    | inactive | priority 40
+ *  - Epsilon Widget  | pending  | priority 50
+ *
+ * BerlinDB's parse_query_var() accepts comma-separated strings for __in and
+ * __not_in filters — PHP arrays must not be passed directly, as BerlinDB
+ * wraps them in another array, taking the single-value code path.
+ *
+ * @since 2.1.0
+ */
+class QueryFilterTest extends TestCase {
+
+	/** @var TestTable */
+	private static $table;
+
+	/** @var TestQuery */
+	private static $query;
+
+	/** @var int[] IDs of the five fixture rows, refreshed in setUp(). */
+	private $ids = array();
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$table = new TestTable();
+		if ( ! self::$table->exists() ) {
+			self::$table->install();
+		}
+		self::$query = new TestQuery();
+	}
+
+	public static function tearDownAfterClass(): void {
+		self::$table->uninstall();
+		parent::tearDownAfterClass();
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// parent::setUp() resets the current user to 0 via clean_up_global_scope().
+		// Re-set here so add_item() passes Query::reduce_item() capability checks.
+		wp_set_current_user( 1 );
+
+		self::$table->delete_all();
+		wp_cache_flush();
+
+		// Insert fresh fixture rows for every test so IDs are always valid.
+		$this->ids[] = self::$query->add_item( array( 'name' => 'Alpha Widget',   'status' => 'active',   'priority' => 10 ) );
+		$this->ids[] = self::$query->add_item( array( 'name' => 'Beta Widget',    'status' => 'active',   'priority' => 20 ) );
+		$this->ids[] = self::$query->add_item( array( 'name' => 'Gamma Gadget',   'status' => 'inactive', 'priority' => 30 ) );
+		$this->ids[] = self::$query->add_item( array( 'name' => 'Delta Gadget',   'status' => 'inactive', 'priority' => 40 ) );
+		$this->ids[] = self::$query->add_item( array( 'name' => 'Epsilon Widget', 'status' => 'pending',  'priority' => 50 ) );
+
+		wp_cache_flush();
+	}
+
+	// Default query
+
+	public function test_query_returns_all_items_with_unlimited_number() {
+		$items = self::$query->query( array( 'number' => 0 ) );
+		$this->assertCount( 5, $items );
+	}
+
+	public function test_query_returns_test_row_instances() {
+		$items = self::$query->query( array( 'number' => 1 ) );
+		$this->assertInstanceOf( TestRow::class, $items[0] );
+	}
+
+	// Status filtering
+
+	public function test_filter_by_status_single_value_returns_correct_count() {
+		$items = self::$query->query( array( 'number' => 0, 'status' => 'active' ) );
+		$this->assertCount( 2, $items );
+	}
+
+	public function test_filter_by_status_single_value_returns_only_matching_items() {
+		$items = self::$query->query( array( 'number' => 0, 'status' => 'active' ) );
+		foreach ( $items as $item ) {
+			$this->assertSame( 'active', $item->status );
+		}
+	}
+
+	public function test_filter_by_status_in_returns_correct_count() {
+		// BerlinDB parse_query_var expects comma-separated strings, not PHP arrays.
+		$items = self::$query->query( array( 'number' => 0, 'status__in' => 'active, pending' ) );
+		$this->assertCount( 3, $items );
+	}
+
+	public function test_filter_by_status_not_in_excludes_inactive() {
+		$items = self::$query->query( array( 'number' => 0, 'status__not_in' => 'inactive' ) );
+		$this->assertCount( 3, $items );
+	}
+
+	public function test_filter_by_status_not_in_excludes_matching_items() {
+		$items = self::$query->query( array( 'number' => 0, 'status__not_in' => 'inactive' ) );
+		foreach ( $items as $item ) {
+			$this->assertNotSame( 'inactive', $item->status );
+		}
+	}
+
+	// Priority filtering
+
+	public function test_filter_by_priority_in_returns_correct_count() {
+		$items = self::$query->query( array( 'number' => 0, 'priority__in' => '10, 30, 50' ) );
+		$this->assertCount( 3, $items );
+	}
+
+	// ID filtering
+
+	public function test_filter_by_id_in_returns_matching_items() {
+		$id_string = implode( ', ', array( $this->ids[0], $this->ids[1] ) );
+		$items     = self::$query->query( array( 'number' => 0, 'id__in' => $id_string ) );
+		$this->assertCount( 2, $items );
+	}
+
+	public function test_filter_by_id_not_in_excludes_one_item() {
+		$items = self::$query->query( array( 'number' => 0, 'id__not_in' => (string) $this->ids[0] ) );
+		$this->assertCount( 4, $items );
+	}
+
+	// Search
+
+	public function test_search_by_widget_returns_three_items() {
+		$items = self::$query->query( array( 'number' => 0, 'search' => 'Widget' ) );
+		$this->assertCount( 3, $items );
+	}
+
+	public function test_search_by_gadget_returns_two_items() {
+		$items = self::$query->query( array( 'number' => 0, 'search' => 'Gadget' ) );
+		$this->assertCount( 2, $items );
+	}
+
+	// Ordering
+
+	public function test_orderby_name_asc_returns_alpha_first() {
+		$items = self::$query->query( array( 'number' => 0, 'orderby' => 'name', 'order' => 'ASC' ) );
+		$this->assertSame( 'Alpha Widget', $items[0]->name );
+	}
+
+	public function test_orderby_name_desc_returns_gamma_first() {
+		$items = self::$query->query( array( 'number' => 0, 'orderby' => 'name', 'order' => 'DESC' ) );
+		$this->assertSame( 'Gamma Gadget', $items[0]->name );
+	}
+
+	public function test_orderby_priority_desc_returns_highest_first() {
+		$items = self::$query->query( array( 'number' => 1, 'orderby' => 'priority', 'order' => 'DESC' ) );
+		$this->assertSame( 50, (int) $items[0]->priority );
+	}
+
+	public function test_orderby_priority_asc_returns_lowest_first() {
+		$items = self::$query->query( array( 'number' => 1, 'orderby' => 'priority', 'order' => 'ASC' ) );
+		$this->assertSame( 10, (int) $items[0]->priority );
+	}
+
+	// Pagination
+
+	public function test_number_limits_result_count() {
+		$items = self::$query->query( array( 'number' => 2 ) );
+		$this->assertCount( 2, $items );
+	}
+
+	public function test_offset_skips_items() {
+		$first_page  = self::$query->query( array( 'number' => 2, 'offset' => 0, 'orderby' => 'id', 'order' => 'ASC' ) );
+		$second_page = self::$query->query( array( 'number' => 2, 'offset' => 2, 'orderby' => 'id', 'order' => 'ASC' ) );
+
+		$this->assertCount( 2, $first_page );
+		$this->assertCount( 2, $second_page );
+		$this->assertNotSame( $first_page[0]->id, $second_page[0]->id );
+	}
+
+	// Count mode
+
+	public function test_count_query_returns_total_row_count() {
+		$count = self::$query->query( array( 'count' => true ) );
+		$this->assertSame( 5, (int) $count );
+	}
+
+	public function test_count_query_with_status_filter_returns_correct_count() {
+		$count = self::$query->query( array( 'count' => true, 'status' => 'active' ) );
+		$this->assertSame( 2, (int) $count );
+	}
+
+	public function test_count_query_with_not_in_filter() {
+		$count = self::$query->query( array( 'count' => true, 'status__not_in' => 'inactive' ) );
+		$this->assertSame( 3, (int) $count );
+	}
+
+	// Fields mode
+
+	public function test_fields_ids_returns_array_of_integers() {
+		$ids = self::$query->query( array( 'number' => 0, 'fields' => 'ids' ) );
+		$this->assertIsArray( $ids );
+		foreach ( $ids as $id ) {
+			$this->assertIsInt( (int) $id );
+		}
+	}
+
+	public function test_fields_ids_returns_all_item_ids() {
+		$ids = self::$query->query( array( 'number' => 0, 'fields' => 'ids' ) );
+		$this->assertCount( 5, $ids );
+	}
+
+	// Found rows / pagination
+
+	public function test_no_found_rows_false_populates_max_num_pages() {
+		self::$query->query( array( 'number' => 2, 'no_found_rows' => false ) );
+
+		// max_num_pages is private, so __get returns null for it (PHP's recursion
+		// guard prevents access from the parent Base::__get context). Use Reflection.
+		$prop = new \ReflectionProperty( \BerlinDB\Database\Query::class, 'max_num_pages' );
+		$prop->setAccessible( true );
+		$this->assertGreaterThan( 1, $prop->getValue( self::$query ) );
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,51 @@
+# BerlinDB Core — PHPUnit Tests
+
+Integration tests for the BerlinDB Core library. These tests require a real
+WordPress installation and a MySQL database; they are not pure unit tests.
+
+## Running Tests
+
+The easiest way to run the suite is via the Docker runner at the repository root:
+
+```bash
+bin/run-tests.sh
+```
+
+See `bin/run-tests.sh --help` for available options (PHP version, WP version,
+PHPUnit filter passthrough).
+
+For manual local runs (requires PHP 7.4+, MySQL, SVN, and Composer):
+
+```bash
+composer install
+bin/install-wp-tests.sh berlindb_tests root '' localhost latest
+vendor/bin/phpunit
+```
+
+## Test Classes
+
+| File | Requires DB | What it covers |
+|------|:-----------:|----------------|
+| `ColumnTest.php` | No | Column defaults, type detection, `special_args()`, `get_create_string()`, validation callbacks |
+| `SchemaTest.php` | No | Column object conversion, `get_create_table_string()`, `clear()`, `add_item()` |
+| `TableTest.php` | Yes | Table lifecycle (`create`, `exists`, `drop`), `count()`, upgrade flow, `column_exists()`, versioning |
+| `QueryCrudTest.php` | Yes | `add_item()`, `get_item()`, `get_item_by()`, `update_item()`, `delete_item()`, `copy_item()` |
+| `QueryFilterTest.php` | Yes | `query()` filtering by status/priority/id, `__in`/`__not_in`, search, orderby, pagination, count mode |
+
+## Fixture Classes
+
+The test fixtures live in `tests/Fixtures/` and provide minimal, concrete
+implementations of the abstract BerlinDB classes:
+
+| Class | Extends | Purpose |
+|-------|---------|---------|
+| `TestSchema` | `Schema` | 7-column schema covering all common column flags |
+| `TestTable` | `Table` | `berlindb_test_widgets` table with an upgrade callback for testing the upgrade flow |
+| `TestRow` | `Row` | Typed row wrapper matching the test schema |
+| `TestQuery` | `Query` | Wires `TestSchema` and `TestRow` together |
+
+## Notes
+
+- The test table is named `berlindb_test_widgets` and is isolated from any real WordPress tables.
+- `wp_set_current_user(1)` is called in the database test classes because `Query::reduce_item()` checks `current_user_can()` before saving column data. Without a logged-in user, `add_item()` silently drops all columns.
+- `wp_cache_flush()` is called between tests to prevent stale object cache from masking CRUD changes.

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ bin/run-tests.sh
 ```
 
 See `bin/run-tests.sh --help` for available options (PHP version, WP version,
-PHPUnit filter passthrough).
+MariaDB version, PHPUnit filter passthrough).
 
 For manual local runs (requires PHP 7.4+, MySQL, SVN, and Composer):
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Schema class tests.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Database\Column;
+use BerlinDB\Tests\Fixtures\TestSchema;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for BerlinDB\Database\Schema.
+ *
+ * Schema is a pure PHP object; no database connection required.
+ *
+ * @since 2.1.0
+ */
+class SchemaTest extends TestCase {
+
+	/** @var TestSchema */
+	private static $schema;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$schema = new TestSchema();
+	}
+
+	public function test_columns_are_converted_to_column_objects() {
+		foreach ( self::$schema->columns as $column ) {
+			$this->assertInstanceOf( Column::class, $column );
+		}
+	}
+
+	public function test_column_count_matches_definition() {
+		$this->assertCount( 7, self::$schema->columns );
+	}
+
+	public function test_exactly_one_primary_column_exists() {
+		$primary = array_filter( self::$schema->columns, static function ( $col ) {
+			return true === $col->primary;
+		} );
+		$this->assertCount( 1, $primary );
+	}
+
+	public function test_primary_column_is_named_id() {
+		$primary = array_filter( self::$schema->columns, static function ( $col ) {
+			return true === $col->primary;
+		} );
+		$col = reset( $primary );
+		$this->assertSame( 'id', $col->name );
+	}
+
+	public function test_searchable_columns_include_name() {
+		$searchable = array_filter( self::$schema->columns, static function ( $col ) {
+			return true === $col->searchable;
+		} );
+		$names = array_map( static function ( $col ) { return $col->name; }, $searchable );
+		$this->assertContains( 'name', array_values( $names ) );
+	}
+
+	public function test_uuid_column_exists_with_correct_properties() {
+		$uuid_cols = array_filter( self::$schema->columns, static function ( $col ) {
+			return 'uuid' === $col->name;
+		} );
+		$this->assertCount( 1, $uuid_cols );
+		$uuid = reset( $uuid_cols );
+		$this->assertTrue( $uuid->uuid );
+		$this->assertFalse( $uuid->searchable );
+		$this->assertFalse( $uuid->sortable );
+	}
+
+	public function test_get_create_table_string_is_not_empty() {
+		$sql = self::$schema->get_create_table_string();
+		$this->assertNotEmpty( $sql );
+	}
+
+	public function test_get_create_table_string_contains_primary_key_directive() {
+		$sql = self::$schema->get_create_table_string();
+		// The Column with primary=true contributes `id` to the CREATE TABLE SQL;
+		// the actual PRIMARY KEY directive comes from the Index, if any, or is
+		// implied. Just verify the column name appears.
+		$this->assertStringContainsString( '`id`', $sql );
+	}
+
+	public function test_get_create_table_string_contains_id_column() {
+		$this->assertStringContainsString( '`id`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_name_column() {
+		$this->assertStringContainsString( '`name`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_status_column() {
+		$this->assertStringContainsString( '`status`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_priority_column() {
+		$this->assertStringContainsString( '`priority`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_date_created_column() {
+		$this->assertStringContainsString( '`date_created`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_date_modified_column() {
+		$this->assertStringContainsString( '`date_modified`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_get_create_table_string_contains_uuid_column() {
+		$this->assertStringContainsString( '`uuid`', self::$schema->get_create_table_string() );
+	}
+
+	public function test_clear_empties_columns_array() {
+		$schema = new TestSchema();
+		$schema->clear( 'columns' );
+		$this->assertEmpty( $schema->columns );
+	}
+
+	public function test_clear_with_no_arg_empties_both_columns_and_indexes() {
+		$schema = new TestSchema();
+		$schema->clear();
+		$this->assertEmpty( $schema->columns );
+		$this->assertEmpty( $schema->indexes );
+	}
+
+	public function test_add_item_appends_a_column_object() {
+		$schema      = new TestSchema();
+		$count_before = count( $schema->columns );
+		$result       = $schema->add_item( 'columns', Column::class, array(
+			'name'   => 'extra_col',
+			'type'   => 'varchar',
+			'length' => '50',
+		) );
+		$this->assertInstanceOf( Column::class, $result );
+		$this->assertCount( $count_before + 1, $schema->columns );
+	}
+
+	public function test_add_item_returns_false_for_empty_data() {
+		$schema = new TestSchema();
+		$result = $schema->add_item( 'columns', Column::class, array() );
+		$this->assertFalse( $result );
+	}
+}

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Table class tests.
+ *
+ * @package     BerlinDB\Tests
+ * @copyright   2026 - JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Tests\Fixtures\TestTable;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for BerlinDB\Database\Table.
+ *
+ * Requires a live database. TestTable uses table name 'berlindb_test_widgets'
+ * to avoid conflicts with real WordPress tables.
+ *
+ * Because Table::is_testing() detects WP_TESTS_DIR, constructing a TestTable
+ * automatically calls maybe_upgrade() → install() on first run.
+ *
+ * @since 2.1.0
+ */
+class TableTest extends TestCase {
+
+	/** @var TestTable */
+	private static $table;
+
+	/** @var int Number of _create_temporary_tables filter instances removed by bypass. */
+	private $bypassed_create_count = 0;
+
+	/** @var int Number of _drop_temporary_tables filter instances removed by bypass. */
+	private $bypassed_drop_count = 0;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$table = new TestTable();
+
+		if ( ! self::$table->exists() ) {
+			self::$table->install();
+		}
+	}
+
+	public static function tearDownAfterClass(): void {
+		self::$table->uninstall();
+		parent::tearDownAfterClass();
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// parent::setUp() calls clean_up_global_scope() which resets the current
+		// user to 0. Re-set here so reduce_item() passes capability checks.
+		wp_set_current_user( 1 );
+
+		// Do NOT attempt to reinstall here. The WP test framework's
+		// _create_temporary_tables filter may be added multiple times across test
+		// runs (if tearDown doesn't drain every instance), and calling install()
+		// while any instance is still active would produce a spurious
+		// "CREATE TEMPORARY TABLE … already exists" error. Tests that drop or
+		// uninstall the table handle their own reinstall via bypass_table_filters().
+		self::$table->delete_all();
+		wp_cache_flush();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Remove ALL active instances of the WP test-framework query filters that
+	 * convert CREATE/DROP TABLE to their TEMPORARY variants, and record the
+	 * count so restore_table_filters() can put them back exactly.
+	 */
+	private function bypass_table_filters(): void {
+		$this->bypassed_create_count = 0;
+		while ( has_filter( 'query', array( $this, '_create_temporary_tables' ) ) ) {
+			remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+			$this->bypassed_create_count++;
+		}
+
+		$this->bypassed_drop_count = 0;
+		while ( has_filter( 'query', array( $this, '_drop_temporary_tables' ) ) ) {
+			remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+			$this->bypassed_drop_count++;
+		}
+	}
+
+	/**
+	 * Restore the exact number of filter instances that bypass_table_filters() removed.
+	 */
+	private function restore_table_filters(): void {
+		for ( $i = 0; $i < $this->bypassed_create_count; $i++ ) {
+			add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		}
+		for ( $i = 0; $i < $this->bypassed_drop_count; $i++ ) {
+			add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Existence
+	// -------------------------------------------------------------------------
+
+	public function test_table_exists_after_install() {
+		$this->assertTrue( self::$table->exists() );
+	}
+
+	public function test_needs_upgrade_returns_false_when_current() {
+		$this->assertFalse( self::$table->needs_upgrade() );
+	}
+
+	public function test_table_does_not_exist_after_uninstall() {
+		$this->bypass_table_filters();
+		self::$table->uninstall();
+		$exists = self::$table->exists();
+		self::$table->install();
+		$this->restore_table_filters();
+
+		$this->assertFalse( $exists );
+	}
+
+	// -------------------------------------------------------------------------
+	// Count
+	// -------------------------------------------------------------------------
+
+	public function test_count_returns_zero_on_empty_table() {
+		$this->assertSame( 0, self::$table->count() );
+	}
+
+	public function test_count_returns_correct_number_after_direct_inserts() {
+		global $wpdb;
+
+		$table_name = $wpdb->berlindb_test_widgets;
+		$wpdb->insert( $table_name, array( 'name' => 'Widget A', 'status' => 'active' ) );
+		$wpdb->insert( $table_name, array( 'name' => 'Widget B', 'status' => 'active' ) );
+		$wpdb->insert( $table_name, array( 'name' => 'Widget C', 'status' => 'inactive' ) );
+
+		$this->assertSame( 3, self::$table->count() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Drop / recreate
+	// -------------------------------------------------------------------------
+
+	public function test_drop_removes_the_table() {
+		$this->bypass_table_filters();
+		self::$table->drop();
+		$exists = self::$table->exists();
+		self::$table->install();
+		$this->restore_table_filters();
+
+		$this->assertFalse( $exists );
+	}
+
+	// -------------------------------------------------------------------------
+	// Versioning
+	// -------------------------------------------------------------------------
+
+	public function test_get_version_returns_string() {
+		$version = self::$table->get_version();
+		$this->assertIsString( $version );
+	}
+
+	// -------------------------------------------------------------------------
+	// Upgrade flow
+	// -------------------------------------------------------------------------
+
+	public function test_upgrade_runs_callback_and_adds_column() {
+		// The upgrades array has key '202604230.1' > stored version '202604230',
+		// so upgrade() finds it as pending and runs __202604230 which adds
+		// a 'notes' column.
+		self::$table->upgrade();
+
+		$this->assertTrue( self::$table->column_exists( 'notes' ) );
+		$this->assertSame( '202604230.1', self::$table->get_version() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Column inspection
+	// -------------------------------------------------------------------------
+
+	public function test_column_exists_for_id_column() {
+		$this->assertTrue( self::$table->column_exists( 'id' ) );
+	}
+
+	public function test_column_exists_for_name_column() {
+		$this->assertTrue( self::$table->column_exists( 'name' ) );
+	}
+
+	public function test_column_exists_returns_false_for_unknown_column() {
+		$this->assertFalse( self::$table->column_exists( 'nonexistent_xyz_column' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Status
+	// -------------------------------------------------------------------------
+
+	public function test_status_returns_result_with_name_property() {
+		$status = self::$table->status();
+		$this->assertNotEmpty( $status );
+		$this->assertNotEmpty( $status->Name );
+	}
+
+	// -------------------------------------------------------------------------
+	// Truncate
+	// -------------------------------------------------------------------------
+
+	public function test_truncate_empties_the_table() {
+		global $wpdb;
+
+		$table_name = $wpdb->berlindb_test_widgets;
+		$wpdb->insert( $table_name, array( 'name' => 'Widget A', 'status' => 'active' ) );
+		$wpdb->insert( $table_name, array( 'name' => 'Widget B', 'status' => 'active' ) );
+
+		self::$table->truncate();
+
+		$this->assertSame( 0, self::$table->count() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Install / uninstall version tracking
+	// -------------------------------------------------------------------------
+
+	public function test_install_sets_db_version() {
+		$this->bypass_table_filters();
+		self::$table->uninstall();
+		self::$table->install();
+		$version = self::$table->get_version();
+		$this->restore_table_filters();
+
+		$this->assertSame( '202604230', $version );
+	}
+
+	public function test_uninstall_deletes_db_version() {
+		$this->bypass_table_filters();
+		self::$table->uninstall();
+		$exists = self::$table->exists();
+		self::$table->install();
+		$this->restore_table_filters();
+
+		$this->assertFalse( $exists );
+	}
+}

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -170,14 +170,27 @@ class TableTest extends TestCase {
 	// Upgrade flow
 	// -------------------------------------------------------------------------
 
+	/**
+	 * Test that an upgrade callback runs and performs its intended schema change.
+	 *
+	 * This indirectly tests that the upgrade() method correctly detects the
+	 * need for an upgrade, runs the callback, and updates the stored version.
+	 *
+	 * Because the upgrade process is triggered by get_version() when the stored
+	 * version is less than the current schema version, this test manually sets
+	 * the stored version to a known pre-upgrade value before calling upgrade().
+	 *
+	 * @since 2.1.0
+	 */
 	public function test_upgrade_runs_callback_and_adds_column() {
-		// The upgrades array has key '202604230.1' > stored version '202604230',
-		// so upgrade() finds it as pending and runs __202604230 which adds
-		// a 'notes' column.
+		$this->assertFalse( self::$table->column_exists( 'notes' ) );
+
+		update_option( self::$table->get_db_version_key(), self::$table->get_schema_version() );
+		self::$table->get_version();
 		self::$table->upgrade();
 
 		$this->assertTrue( self::$table->column_exists( 'notes' ) );
-		$this->assertSame( '202604230.1', self::$table->get_version() );
+		$this->assertSame( '202604231', self::$table->get_version() );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * PHPUnit bootstrap for BerlinDB Core integration tests.
+ *
+ * @package BerlinDB\Tests
+ * @copyright   Copyright (c) 2026, JJJ and all BerlinDB contributors
+ * @license     https://opensource.org/licenses/MIT MIT
+ * @since       2.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use Yoast\WPTestUtils\WPIntegration;
+
+$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+$_SERVER['SERVER_NAME']     = '';
+$PHP_SELF                   = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
+
+define( 'WP_USE_THEMES', false );
+
+$library_dir = dirname( __DIR__ );
+
+// Load Composer autoloader (BerlinDB classes + yoast packages).
+require_once $library_dir . '/vendor/autoload.php';
+
+// Load yoast WP test utils bootstrap helpers.
+require_once $library_dir . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+// Resolve WP_TESTS_DIR (env var → constant → /tmp/wordpress-tests-lib).
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
+
+if ( ! defined( 'WP_TESTS_DIR' ) ) {
+	define( 'WP_TESTS_DIR', $_tests_dir );
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo 'Could not find ' . $_tests_dir . '/includes/functions.php' . PHP_EOL;
+	echo 'Set WP_TESTS_DIR to the WordPress test suite path.' . PHP_EOL;
+	exit( 1 );
+}
+
+// Give access to tests_add_filter().
+require_once $_tests_dir . '/includes/functions.php';
+
+// BerlinDB is a library loaded via Composer — no plugin to activate.
+// bootstrap_it() defines ABSPATH, which every src/ file guards against.
+WPIntegration\bootstrap_it();
+
+// Load test fixture classes after ABSPATH is defined.
+require_once __DIR__ . '/Fixtures/TestSchema.php';
+require_once __DIR__ . '/Fixtures/TestRow.php';
+require_once __DIR__ . '/Fixtures/TestTable.php';
+require_once __DIR__ . '/Fixtures/TestQuery.php';


### PR DESCRIPTION
### Summary

Adds a full integration test suite for BerlinDB Core. The suite requires a real WordPress installation and MySQL database (not mocks), and includes a Docker-based runner that handles all environment setup automatically.

Three small production-code fixes are included; all three were surfaced by writing the tests and would not have been found otherwise.

### Test infrastructure

**Running tests**

The easiest path is Docker:

```bash
bin/run-tests.sh
```

Options:
- `-p <version>` — PHP version (default: 8.2)
- `-w <version>` — WordPress version (default: latest)
- `-d <version>` — MariaDB version (default: 10.2)
- `--filter ClassName` — pass arguments through to PHPUnit

For local runs without Docker (requires PHP 7.4+, MySQL, SVN, Composer):

```bash
composer install
bin/install-wp-tests.sh berlindb_tests root '' localhost latest
vendor/bin/phpunit
```

**Fixture classes** (`tests/Fixtures/`)

BerlinDB's core classes are all abstract, so the test suite needs concrete implementations to exercise them against a real database. Four fixture classes provide the minimum viable implementations:

| Class        | Extends  | Purpose                                                                                                                                              |
| ------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| `TestSchema` | `Schema` | 7-column schema covering all common column flags (`searchable`, `sortable`, `cache_key`, `transition`, `in`/`not_in`, `uuid`, `created`, `modified`) |
| `TestTable`  | `Table`  | `berlindb_test_widgets` table with a registered upgrade callback, exposing internal keys for test manipulation                                       |
| `TestRow`    | `Row`    | Typed row wrapper matching the test schema                                                                                                           |
| `TestQuery`  | `Query`  | Wires `TestSchema` and `TestRow` together                                                                                                            |

The test table name (`berlindb_test_widgets`) is intentionally namespaced to avoid collisions with any real WordPress tables in the test environment.

**Test classes**

| File              | DB required | What it covers                                                                                        |
| ----------------- | :---------: | ----------------------------------------------------------------------------------------------------- |
| `ColumnTest`      | No          | Column defaults, type detection, `special_args()`, `get_create_string()`, validation callbacks        |
| `SchemaTest`      | No          | Column object conversion, `get_create_table_string()`, `clear()`, `add_item()`                        |
| `TableTest`       | Yes         | Table lifecycle (`create`, `exists`, `drop`), `count()`, upgrade flow, `column_exists()`, versioning  |
| `QueryCrudTest`   | Yes         | `add_item()`, `get_item()`, `get_item_by()`, `update_item()`, `delete_item()`, `copy_item()`          |
| `QueryFilterTest` | Yes         | `query()` filtering by status/priority/id, `__in`/`__not_in`, search, orderby, pagination, count mode |
| `QueryCacheTest`  | Yes         | Cache key stability across Query instances, cache hit on repeated identical queries                   |

**Non-obvious test setup details**

Two behaviors in the WordPress test framework required explicit workarounds, documented in the test code:

1. **Current user** — `parent::setUp()` calls `clean_up_global_scope()`, which resets the current user to 0. `Query::reduce_item()` checks `current_user_can()` before saving column data, so without `wp_set_current_user(1)` in each `setUp()`, `add_item()` silently succeeds but drops every column. This would make CRUD tests pass vacuously.

2. **Temporary table filter** — The WP test framework intercepts `CREATE TABLE` and `DROP TABLE` queries and converts them to their `TEMPORARY` variants. This is useful for most tests (the table is recreated fresh each run without touching a persistent database), but it prevents testing the actual table lifecycle (install, drop, uninstall). Tests that need real persistent tables call `bypass_table_filters()` / `restore_table_filters()` helpers that remove and restore the exact number of active filter instances.

---

### Production code fixes

**`Table.php`: String-cast versions before `version_compare()`**

`Table.php` declares `strict_types=1`. PHP coerces pure-numeric string array keys to `int` at runtime, which means an upgrade key like `'202604231'` becomes the integer `202604231`. `version_compare()` under strict types then throws a `TypeError`.

Fixed by casting both arguments to `(string)` in the two `version_compare()` call sites in `Table.php`, and changing the `get_db_version()` fallback default from `1` (int) to `''` (string). `get_version()` now has an explicit `string` return type declaration and casts its return value. This was invisible without tests because the upgrade path is only exercised when a stored version differs from the schema version.

**Note:** I intentionally set the table versions for the tests to these values because the earliest implementers for Berlin use this format, so it's a valid real life version that won't work with the current `release/2.1.0` work.

**`Query.php`: Don't bump `last_changed` on cache-warming reads**

`update_item_cache()` was unconditionally calling `update_last_changed_cache()` after every call, including the two read-path calls (single item fetch and batch fetch). Bumping `last_changed` on a read invalidates the list-query cache that was just populated, so a subsequent list query always misses the cache.

Fixed by adding a `$bump_last_changed` parameter (default `true`) and passing `false` from the two read-path callers. Mutation callers (insert/update/delete) retain the default `true` behavior. The `QueryCacheTest` class specifically tests that a repeated identical query hits the cache and fires no additional SQL.

**Note:** This is a followup to the fix for #184; the tests originally set up for EDD passed because no refunds existed, but when applying the same tests to Berlin and querying rows that do actually exist, the tests failed. When no rows are found, the item shaping methods are never called, and that's what bumps the last changed values. The fix has been applied to EDD and tests updated there as well.