### PR TITLE
Query: prevent invalidated query caches from accumulating.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -891,8 +891,14 @@ class Query extends Base {
 		}
 
 		// Check the cache
-		$cache_key   = $this->get_cache_key();
-		$cache_value = $this->cache_get( $cache_key, $this->cache_group );
+		$cache_key    = $this->get_cache_key();
+		$last_changed = $this->get_last_changed_cache();
+		$cache_value  = $this->cache_get( $cache_key, $this->cache_group );
+
+		// Ignore results from an earlier cache generation
+		if ( ! is_array( $cache_value ) || ! isset( $cache_value['last_changed'] ) || ( $last_changed !== $cache_value['last_changed'] ) ) {
+			$cache_value = false;
+		}
 
 		// No cache value
 		if ( false === $cache_value ) {
@@ -903,12 +909,13 @@ class Query extends Base {
 
 			// Format the cached value
 			$cache_value = array(
-				'item_ids'    => $item_ids,
-				'found_items' => intval( $this->found_items ),
+				'item_ids'     => $item_ids,
+				'found_items'  => intval( $this->found_items ),
+				'last_changed' => $last_changed,
 			);
 
-			// Add value to the cache
-			$this->cache_add( $cache_key, $cache_value, $this->cache_group );
+			// Replace results under the same key after invalidation
+			$this->cache_set( $cache_key, $cache_value, $this->cache_group );
 
 		// Value exists in cache
 		} else {
@@ -2605,12 +2612,18 @@ class Query extends Base {
 		// Unset `fields` so it does not effect the cache key
 		unset( $slice['fields'] );
 
-		// Setup key & last_changed
-		$key          = md5( serialize( $slice ) );
-		$last_changed = $this->get_last_changed_cache( $group );
+		// Remove per-instance defaults so identical queries share a key
+		foreach ( $slice as $name => $value ) {
+			if ( $value === $this->query_var_default_value ) {
+				unset( $slice[ $name ] );
+			}
+		}
+
+		// Hash the query independently of its cache generation
+		$key = md5( serialize( $slice ) );
 
 		// Concatenate and return cache key
-		return "get_{$this->item_name_plural}:{$key}:{$last_changed}";
+		return "get_{$this->item_name_plural}:{$key}";
 	}
 
 	/**


### PR DESCRIPTION
Invalidating a query currently creates another persistent cache key. This maintenance fix stores the generation with the cached results and replaces stale results at a stable key, preventing successive invalidations of the same query from accumulating entries.

Remove unset-value sentinels from the query hash, following Robin Cornett's correction in #185, so equivalent query instances use the same key. The generation is captured before reading the database and checked when reading cached results.

This changes only two methods in `src/Database/Query.php`, with no new API, dependencies, or minimum runtime requirements. Existing orphaned cache entries are not removed by this fix. Distinct queries still have distinct cache entries; this does not introduce expiration.

Validation was performed outside the maintenance branch, with no test infrastructure added to the release:

- WordPress 6.7.7, PHP 8.2, MariaDB 10.2, and Redis 7: 14 tests, 60 assertions passed using a test-only Redis adapter.
- Default WordPress object cache: 14 tests, 56 assertions, one expected Redis-only skip.
- The initial regression suite failed eight tests against unpatched 2.0.2.
- PHP 7.4 syntax and `git diff --check` passed.
- Claude reviewed the patch and found no blocking defects; the additional suggested regression cases passed.

Props @hellofromahmed (Ahmed Saeed) for reporting the persistent-cache growth, and @robincornett (Robin Cornett) for the original unset-value cache-key correction.

See #253, #184, #185. This PR addresses the 2.0.x maintenance line; #253 stays open for the 3.x up-port.
