### PR TITLE
Query: prevent invalidated query caches from accumulating in 3.0.

### DIFF
--- a/src/Database/Kern/Query.php
+++ b/src/Database/Kern/Query.php
@@ -1196,9 +1196,15 @@ class Query {
 		// Check the cache.
 		$cache_results = (bool) $this->get_query_var( 'cache_results' );
 		$cache_key     = $this->get_cache_key();
+		$last_changed  = $this->get_last_changed_cache();
 		$cache_value   = ( true === $cache_results )
 			? $this->cache_get( $cache_key, $this->cache_group )
 			: false;
+
+		// Ignore results from an earlier cache generation.
+		if ( ! is_array( $cache_value ) || ! isset( $cache_value[ 'last_changed' ] ) || ( $last_changed !== $cache_value[ 'last_changed' ] ) ) {
+			$cache_value = false;
+		}
 
 		// No cache value.
 		if ( false === $cache_value ) {
@@ -1211,23 +1217,21 @@ class Query {
 
 			// Format the cached value.
 			$cache_value = array(
-				'item_ids'    => $result,
-				'found_items' => $this->get_current_int( 'found_items' ),
+				'item_ids'     => $result,
+				'found_items'  => $this->get_current_int( 'found_items' ),
+				'last_changed' => $last_changed,
 			);
 
 			// Only store when caching is enabled for this query.
 			if ( $cache_results ) {
-				$this->cache_add( $cache_key, $cache_value, $this->cache_group );
+				$this->cache_set( $cache_key, $cache_value, $this->cache_group );
 			}
 
 			// Value exists in cache.
-		} elseif ( is_array( $cache_value ) ) {
+		} else {
 			$result          = $cache_value[ 'item_ids' ] ?? array();
 			$found_items_val = $cache_value[ 'found_items' ] ?? 0;
 			$this->set_current( 'found_items', (int) $found_items_val );
-		} else {
-			$result = array();
-			$this->set_current( 'found_items', 0 );
 		}
 
 		// Pagination.
@@ -3313,15 +3317,14 @@ class Query {
 	 * - Sorts query_vars by query_var_default keys
 	 * - Removes query_vars with default values
 	 * - Serializes and md5 hashes query_vars
-	 * - Combines plural name, key, and last_changed for cache group
+	 * - Combines plural name and hash independently of the cache generation
 	 *
 	 * @since 1.0.0
 	 * @since 2.1.0 Correctly removes unique query_var_default_value values
 	 *
-	 * @param string $group Cache group name.
 	 * @return string
 	 */
-	private function get_cache_key( $group = '' ) {
+	private function get_cache_key() {
 
 		// Default slice.
 		$slice = array();
@@ -3348,13 +3351,12 @@ class Query {
 			$slice[ $key ] = $this->query_vars[ $key ];
 		}
 
-		// Setup key & last_changed.
+		// Hash the query independently of its cache generation.
 		$key              = md5( serialize( $slice ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-		$last_changed     = $this->get_last_changed_cache( $group );
 		$item_name_plural = $this->get_item_name_plural();
 
 		// Return the concatenated cache key.
-		return "get_{$item_name_plural}:{$key}:{$last_changed}";
+		return "get_{$item_name_plural}:{$key}";
 	}
 
 	/**

--- a/tests/Database/Query/QueryCacheTest.php
+++ b/tests/Database/Query/QueryCacheTest.php
@@ -244,4 +244,118 @@ class QueryCacheTest extends TestCase {
 			'cache_results must not segment the cache key.'
 		);
 	}
+
+	/**
+	 * Repeated mutations replace one result entry and preserve warm cache hits.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_invalidated_results_replace_the_same_cache_entry(): void {
+		global $wpdb;
+
+		$args    = array(
+			'status' => 'active',
+			'number' => 10,
+		);
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$query   = new TestQuery( $args );
+		$key     = $get_key->invoke( $query );
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$id = self::$query->add_item(
+				array(
+					'name'   => 'New Widget',
+					'status' => 'active',
+				)
+			);
+			$this->assertCount( 2, $query->query( $args ) );
+			$this->assertSame( $key, $get_key->invoke( $query ) );
+
+			self::$query->delete_item( $id );
+			$this->assertCount( 1, $query->query( $args ) );
+			$this->assertSame( $key, $get_key->invoke( $query ) );
+
+			$cached = wp_cache_get( $key, $group );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $cached['last_changed'] );
+			$this->assertCount( 1, $cached['item_ids'] );
+
+			$before = $wpdb->num_queries;
+			$this->assertCount( 1, $query->query( $args ) );
+			$this->assertSame( $before, $wpdb->num_queries );
+		}
+	}
+
+	/**
+	 * Entries without a matching generation must be replaced, including empties.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_missing_or_stale_generations_are_replaced(): void {
+		$args    = array(
+			'status' => 'inactive',
+			'number' => 10,
+		);
+		$query   = new TestQuery( $args );
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$key     = $get_key->invoke( $query );
+
+		foreach ( array( false, 'obsolete' ) as $generation ) {
+			$entry = array(
+				'item_ids'    => array( 999999 ),
+				'found_items' => 1,
+			);
+			if ( false !== $generation ) {
+				$entry['last_changed'] = $generation;
+			}
+			wp_cache_set( $key, $entry, $group );
+
+			$this->assertSame( array(), $query->query( $args ) );
+			$cached = wp_cache_get( $key, $group );
+			$this->assertSame( array(), $cached['item_ids'] );
+			$this->assertSame( 0, $cached['found_items'] );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $cached['last_changed'] );
+		}
+	}
+
+	/**
+	 * An invalidation during a database read cannot label old results as current.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_generation_is_captured_before_the_database_read(): void {
+		global $wpdb;
+
+		$args    = array(
+			'status' => 'active',
+			'number' => 10,
+		);
+		$query   = new TestQuery( $args );
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$key     = $get_key->invoke( $query );
+		wp_cache_delete( $key, $group );
+		$before = wp_cache_get( 'last_changed', $group );
+		$rotate = static function ( $sql ) use ( $group ) {
+			if ( false !== strpos( $sql, 'SELECT' ) && false !== strpos( $sql, 'test_widgets' ) ) {
+				wp_cache_set( 'last_changed', 'during-read', $group );
+			}
+			return $sql;
+		};
+
+		add_filter( 'query', $rotate );
+		try {
+			$query->query( $args );
+		} finally {
+			remove_filter( 'query', $rotate );
+		}
+
+		$cached = wp_cache_get( $key, $group );
+		$this->assertSame( $before, $cached['last_changed'] );
+		$this->assertSame( 'during-read', wp_cache_get( 'last_changed', $group ) );
+		$queries_before = $wpdb->num_queries;
+		$this->assertCount( 1, $query->query( $args ) );
+		$this->assertGreaterThan( $queries_before, $wpdb->num_queries );
+	}
 }


### PR DESCRIPTION
Port the 2.0.3 query-result cache fix to the released 3.0 line. Repeated invalidations now replace the result at one stable key instead of accumulating generation-suffixed keys. Each entry carries the generation captured before its database read; entries with missing or stale generations are replaced.

Robin's unset-value cache-key correction already exists in 3.0.0. Remove the now-unused private `get_cache_key()` parameter, as noted in the review of #254. No public API or runtime requirement changes.

Validation:

- PHP 8.1 and 8.2, WordPress 6.7.7, MariaDB 10.2: 617 tests / 1,209 assertions passed on each PHP version.
- Redis 7, using an external test-only adapter: 9 cache tests / 43 assertions passed.
- All three new regression methods fail against unpatched 3.0.0 (two failures and one missing-generation error).
- Composer validation, PHPStan, PHPCS, and diff checks passed.

Existing orphaned entries are not removed, and distinct query entries do not gain an expiration policy. The development-branch up-port is separate.

Props @hellofromahmed for reporting #253 and @robincornett for the existing sentinel correction (#185).

See #253, #254, #185.
