### PR TITLE
Query: prevent invalidated query caches from accumulating.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ hand-rolled queries — never more surprising.
    vendor/bin/phpcs
    ```
 5. **Don't invent APIs.** If unsure how something behaves, search `src/` and
-   `tests/` — the source and its 1721 test methods are the source of truth, ahead
+   `tests/` — the source and its 1724 test methods are the source of truth, ahead
    of memory or training data. (PHPUnit reports more cases: data providers expand
    methods at run time.)
 6. **Keep changes focused and tested.** Bug fixes and new behavior ship with

--- a/src/Database/Traits/Query/Cache.php
+++ b/src/Database/Traits/Query/Cache.php
@@ -68,15 +68,14 @@ trait Cache {
 	 * - Sorts query_vars by query_var_default keys
 	 * - Removes query_vars with default values
 	 * - Serializes and md5 hashes query_vars
-	 * - Combines plural name, key, and last_changed for cache group
+	 * - Combines plural name and hash independently of the cache generation
 	 *
 	 * @since 1.0.0
 	 * @since 2.1.0 Correctly removes unique query_var_default_value values
 	 *
-	 * @param string $group Cache group name.
 	 * @return string
 	 */
-	private function get_cache_key( $group = '' ): string {
+	private function get_cache_key(): string {
 
 		// Default slice.
 		$slice = array();
@@ -106,8 +105,8 @@ trait Cache {
 		// Hash the sliced query vars. serialize() is intentional and safe here.
 		$hash = md5( serialize( $slice ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		// Return the namespaced, salted cache key.
-		return "get_{$this->get_item_name_plural()}:{$hash}:" . $this->get_last_changed_cache( $group );
+		// Return the namespaced cache key.
+		return "get_{$this->get_item_name_plural()}:{$hash}";
 	}
 
 	/**
@@ -1013,8 +1012,9 @@ trait Cache {
 				$this->cache_set(
 					$this->get_cache_key(),
 					array(
-						'item_ids'    => $ids,
-						'found_items' => count( $ids ),
+						'item_ids'     => $ids,
+						'found_items'  => count( $ids ),
+						'last_changed' => $this->get_last_changed_cache(),
 					),
 					$this->cache_group
 				);

--- a/src/Database/Traits/Query/Execution.php
+++ b/src/Database/Traits/Query/Execution.php
@@ -156,9 +156,15 @@ trait Execution {
 		$cache_results = (bool) $this->get_query_var( 'cache_results' )
 			&& empty( $this->get_query_var( 'explain' ) );
 		$cache_key     = $this->get_cache_key();
+		$last_changed  = $this->get_last_changed_cache();
 		$cache_value   = ( true === $cache_results )
 			? $this->cache_get( $cache_key, $this->cache_group )
 			: false;
+
+		// Ignore results from an earlier cache generation.
+		if ( ! is_array( $cache_value ) || ! isset( $cache_value[ 'last_changed' ] ) || ( $last_changed !== $cache_value[ 'last_changed' ] ) ) {
+			$cache_value = false;
+		}
 
 		// No cache value.
 		if ( false === $cache_value ) {
@@ -171,23 +177,21 @@ trait Execution {
 
 			// Format the cached value.
 			$cache_value = array(
-				'item_ids'    => $result,
-				'found_items' => $this->get_current_int( 'found_items' ),
+				'item_ids'     => $result,
+				'found_items'  => $this->get_current_int( 'found_items' ),
+				'last_changed' => $last_changed,
 			);
 
 			// Only store when caching is enabled for this query.
 			if ( true === $cache_results ) {
-				$this->cache_add( $cache_key, $cache_value, $this->cache_group );
+				$this->cache_set( $cache_key, $cache_value, $this->cache_group );
 			}
 
 			// Value exists in cache.
-		} elseif ( is_array( $cache_value ) ) {
+		} else {
 			$result          = $cache_value[ 'item_ids' ] ?? array();
 			$found_items_val = $cache_value[ 'found_items' ] ?? 0;
 			$this->set_current( 'found_items', (int) $found_items_val );
-		} else {
-			$result = array();
-			$this->set_current( 'found_items', 0 );
 		}
 
 		// Pagination.

--- a/tests/Database/Kern/Query/QueryCacheTest.php
+++ b/tests/Database/Kern/Query/QueryCacheTest.php
@@ -265,4 +265,118 @@ class QueryCacheTest extends TestCase {
 			'cache_results must not segment the cache key.'
 		);
 	}
+
+	/**
+	 * Repeated mutations replace one result entry and preserve warm cache hits.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_invalidated_results_replace_the_same_cache_entry(): void {
+		global $wpdb;
+
+		$args    = array(
+			'status' => 'active',
+			'number' => 10,
+		);
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$query   = new TestQuery( $args );
+		$key     = $get_key->invoke( $query );
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$id = self::$query->add_item(
+				array(
+					'name'   => 'New Widget',
+					'status' => 'active',
+				)
+			);
+			$this->assertCount( 2, $query->query( $args ) );
+			$this->assertSame( $key, $get_key->invoke( $query ) );
+
+			self::$query->delete_item( $id );
+			$this->assertCount( 1, $query->query( $args ) );
+			$this->assertSame( $key, $get_key->invoke( $query ) );
+
+			$cached = wp_cache_get( $key, $group );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $cached['last_changed'] );
+			$this->assertCount( 1, $cached['item_ids'] );
+
+			$before = $wpdb->num_queries;
+			$this->assertCount( 1, $query->query( $args ) );
+			$this->assertSame( $before, $wpdb->num_queries );
+		}
+	}
+
+	/**
+	 * Entries without a matching generation must be replaced, including empties.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_missing_or_stale_generations_are_replaced(): void {
+		$args    = array(
+			'status' => 'inactive',
+			'number' => 10,
+		);
+		$query   = new TestQuery( $args );
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$key     = $get_key->invoke( $query );
+
+		foreach ( array( false, 'obsolete' ) as $generation ) {
+			$entry = array(
+				'item_ids'    => array( 999999 ),
+				'found_items' => 1,
+			);
+			if ( false !== $generation ) {
+				$entry['last_changed'] = $generation;
+			}
+			wp_cache_set( $key, $entry, $group );
+
+			$this->assertSame( array(), $query->query( $args ) );
+			$cached = wp_cache_get( $key, $group );
+			$this->assertSame( array(), $cached['item_ids'] );
+			$this->assertSame( 0, $cached['found_items'] );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $cached['last_changed'] );
+		}
+	}
+
+	/**
+	 * An invalidation during a database read cannot label old results as current.
+	 *
+	 * @since 3.0.1
+	 */
+	public function test_generation_is_captured_before_the_database_read(): void {
+		global $wpdb;
+
+		$args    = array(
+			'status' => 'active',
+			'number' => 10,
+		);
+		$query   = new TestQuery( $args );
+		$get_key = new \ReflectionMethod( TestQuery::class, 'get_cache_key' );
+		$group   = ( new \ReflectionMethod( TestQuery::class, 'get_cache_group' ) )->invoke( self::$query );
+		$key     = $get_key->invoke( $query );
+		wp_cache_delete( $key, $group );
+		$before = wp_cache_get( 'last_changed', $group );
+		$rotate = static function ( $sql ) use ( $group ) {
+			if ( false !== strpos( $sql, 'SELECT' ) && false !== strpos( $sql, 'test_widgets' ) ) {
+				wp_cache_set( 'last_changed', 'during-read', $group );
+			}
+			return $sql;
+		};
+
+		add_filter( 'query', $rotate );
+		try {
+			$query->query( $args );
+		} finally {
+			remove_filter( 'query', $rotate );
+		}
+
+		$cached = wp_cache_get( $key, $group );
+		$this->assertSame( $before, $cached['last_changed'] );
+		$this->assertSame( 'during-read', wp_cache_get( 'last_changed', $group ) );
+		$queries_before = $wpdb->num_queries;
+		$this->assertCount( 1, $query->query( $args ) );
+		$this->assertGreaterThan( $queries_before, $wpdb->num_queries );
+	}
 }


### PR DESCRIPTION
Port the maintenance query-result cache fix to the development branch. Repeated invalidations replace results at a stable key, with the generation stored in the value and checked before reuse. Capture the generation before normal query reads, update relationship result-cache priming to write the same format, and remove the unused private cache-key parameter.

The existing sentinel normalization remains intact. Add regression tests for replacement after mutations, empty results, missing/stale generations, and invalidation during a database read; update the enforced test-method count.

Validation: PHP 8.1 and 8.2 with WordPress 6.7.7 and MariaDB 10.2 each passed 1,761 tests / 3,861 assertions, including existing relationship priming tests. Composer validation, PHPStan, PHPCS, and diff checks passed.

This ports the focused query-result fix. Existing orphaned entries are not removed, distinct queries do not gain expiration, and the development branch's separate generation-suffixed secondary lookup caches are unchanged.

Props @hellofromahmed for reporting #253 and @robincornett for the existing sentinel correction (#185).

See #253, #254, #185.
