### PR TITLE
Query: prevent secondary lookup caches from accumulating.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ hand-rolled queries — never more surprising.
    vendor/bin/phpcs
    ```
 5. **Don't invent APIs.** If unsure how something behaves, search `src/` and
-   `tests/` — the source and its 1724 test methods are the source of truth, ahead
+   `tests/` — the source and its 1727 test methods are the source of truth, ahead
    of memory or training data. (PHPUnit reports more cases: data providers expand
    methods at run time.)
 6. **Keep changes focused and tested.** Bug fixes and new behavior ship with

--- a/src/Database/Traits/Query/Cache.php
+++ b/src/Database/Traits/Query/Cache.php
@@ -110,20 +110,19 @@ trait Cache {
 	}
 
 	/**
-	 * Build a last_changed-salted cache key for a secondary get_item_by() lookup.
+	 * Build a stable cache key for a secondary get_item_by() lookup.
 	 *
 	 * The cache group already identifies the lookup column, so the key only
-	 * needs the looked-up value and table-wide generation salt. The cached value
-	 * is the primary ID; the object itself lives in the canonical by-id cache.
+	 * needs the looked-up value. The cached value holds the primary ID and the
+	 * lookup group generation; the object lives in the canonical by-id cache.
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param mixed  $column_value Value being looked up.
-	 * @param string $group        Secondary lookup group to salt from. Default empty.
+	 * @param mixed $column_value Value being looked up.
 	 * @return string
 	 */
-	private function get_item_cache_key( $column_value = '', $group = '' ): string {
-		return md5( (string) $column_value ) . ':' . $this->get_last_changed_cache( $group );
+	private function get_item_cache_key( $column_value = '' ): string {
+		return md5( (string) $column_value );
 	}
 
 	/**
@@ -1068,9 +1067,8 @@ trait Cache {
 
 		/*
 		 * Warm the primary by-id object cache only. Secondary cache_key lookups
-		 * are salted and lazily populated by get_item_by(); proactively warming
-		 * them here would write keys the salted reads never hit, and overwrite
-		 * non-unique lookups with the last-written row.
+		 * are lazily populated by get_item_by(); proactively warming them here
+		 * would overwrite non-unique lookups with the last-written row.
 		 */
 		foreach ( $items as $item ) {
 

--- a/src/Database/Traits/Query/Crud.php
+++ b/src/Database/Traits/Query/Crud.php
@@ -318,11 +318,13 @@ trait Crud {
 		 * Cache key. The primary column is stable and unique, so its value (the
 		 * id) is used directly as a by-id object-cache key. Secondary cache_key
 		 * columns use a dedicated "{cache_group}-by-{name}" group and a value
-		 * hash salted with last_changed.
+		 * hash independent of last_changed.
 		 */
-		$cache_key = $column_value;
+		$cache_key    = $column_value;
+		$last_changed = '';
 		if ( ( false === $is_primary ) && ! empty( $group ) ) {
-			$cache_key = $this->get_item_cache_key( $column_value, $group );
+			$cache_key    = $this->get_item_cache_key( $column_value );
+			$last_changed = $this->get_last_changed_cache( $group );
 		}
 
 		// Check cache.
@@ -330,9 +332,14 @@ trait Crud {
 			$retval = $this->cache_get( $cache_key, $group );
 		}
 
-		// Secondary cache hits store the primary ID; resolve via by-id cache.
+		// Resolve current secondary entries through the canonical by-id cache.
 		if ( ( false === $is_primary ) && false !== $retval ) {
-			return $this->get_item( $retval );
+			if ( is_array( $retval ) && isset( $retval[ 'item_id' ], $retval[ 'last_changed' ] ) && ( $last_changed === $retval[ 'last_changed' ] ) ) {
+				return $this->get_item( $retval[ 'item_id' ] );
+			}
+
+			// Ignore entries from an earlier cache generation or format.
+			$retval = false;
 		}
 
 		// Item not cached.
@@ -352,9 +359,16 @@ trait Crud {
 				// Always warm the canonical primary by-id object cache.
 				$this->update_item_cache( $retval, false );
 
-				// For secondary cache_key columns, store only the primary ID.
+				// Replace the secondary entry using the generation from before the read.
 				if ( ( false === $is_primary ) && ! empty( $group ) && isset( $retval->{$primary} ) ) {
-					$this->cache_set( $cache_key, $retval->{$primary}, $group );
+					$this->cache_set(
+						$cache_key,
+						array(
+							'item_id'      => $retval->{$primary},
+							'last_changed' => $last_changed,
+						),
+						$group
+					);
 				}
 			}
 		}

--- a/tests/Database/Kern/Query/QueryCacheKeyByValueTest.php
+++ b/tests/Database/Kern/Query/QueryCacheKeyByValueTest.php
@@ -3,8 +3,8 @@
  * Coherence tests for get_item_by() and the cache_key column caching path.
  *
  * BerlinDB caches single items looked up by a cache_key column. Secondary
- * (non-primary) lookups cache the matching primary ID using the lookup group's
- * last_changed salt and are populated lazily from the actual query result, so:
+ * (non-primary) lookups cache the matching primary ID and lookup group generation under a
+ * stable value key, populated lazily from the actual query result, so:
  *
  *   1. Stale-after-transition: writes that can affect a cache_key mapping bump
  *      that lookup group's last_changed, so a lookup by an old value re-resolves
@@ -434,5 +434,99 @@ class QueryCacheKeyByValueTest extends TestCase {
 		$this->add_widget( array( 'status' => 'active' ) );
 
 		$this->assertFalse( $query->get_item_by( 'status', 'nonexistent' ) );
+	}
+
+	/**
+	 * Repeated transitions replace one secondary entry and preserve warm hits.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_secondary_entry_is_replaced_at_a_stable_key(): void {
+		global $wpdb;
+
+		$query = new TestQuery();
+		$id    = $this->add_widget( array( 'status' => 'active' ) );
+		$group = ( new \ReflectionMethod( $query, 'get_cache_group_for_column' ) )->invoke( $query, 'status' );
+		$key   = md5( 'active' );
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->assertSame( $id, (int) $query->get_item_by( 'status', 'active' )->id );
+			$entry = wp_cache_get( $key, $group );
+			$this->assertIsArray( $entry );
+			$this->assertSame( $id, (int) $entry['item_id'] );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $entry['last_changed'] );
+
+			$before = $wpdb->num_queries;
+			$query->get_item_by( 'status', 'active' );
+			$this->assertSame( $before, $wpdb->num_queries );
+
+			$query->update_item( $id, array( 'status' => 'inactive' ) );
+			$this->assertFalse( $query->get_item_by( 'status', 'active' ) );
+			$query->update_item( $id, array( 'status' => 'active' ) );
+		}
+	}
+
+	/**
+	 * Missing or stale generations and legacy scalar IDs cannot serve a hit.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_secondary_entries_require_a_matching_generation(): void {
+		$query = new TestQuery();
+		$id    = $this->add_widget( array( 'status' => 'active' ) );
+		$wrong = $this->add_widget( array( 'status' => 'inactive' ) );
+		$group = ( new \ReflectionMethod( $query, 'get_cache_group_for_column' ) )->invoke( $query, 'status' );
+		$key   = md5( 'active' );
+
+		foreach ( array(
+			$wrong,
+			array( 'item_id' => $wrong ),
+			array(
+				'item_id'      => $wrong,
+				'last_changed' => 'obsolete',
+			),
+		) as $entry ) {
+			wp_cache_set( $key, $entry, $group );
+			$this->assertSame( $id, (int) $query->get_item_by( 'status', 'active' )->id );
+			$cached = wp_cache_get( $key, $group );
+			$this->assertIsArray( $cached );
+			$this->assertSame( $id, (int) $cached['item_id'] );
+			$this->assertSame( wp_cache_get( 'last_changed', $group ), $cached['last_changed'] );
+		}
+	}
+
+	/**
+	 * A generation change during a lookup forces the next lookup to read again.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_secondary_generation_is_captured_before_the_read(): void {
+		global $wpdb;
+
+		$query  = new TestQuery();
+		$id     = $this->add_widget( array( 'status' => 'active' ) );
+		$group  = ( new \ReflectionMethod( $query, 'get_cache_group_for_column' ) )->invoke( $query, 'status' );
+		$old    = wp_cache_get( 'last_changed', $group );
+		$rotate = static function ( $sql ) use ( $group ) {
+			if ( false !== strpos( $sql, 'SELECT' ) && false !== strpos( $sql, 'test_widgets' ) ) {
+				wp_cache_set( 'last_changed', 'during-read', $group );
+			}
+			return $sql;
+		};
+
+		add_filter( 'query', $rotate );
+		try {
+			$query->get_item_by( 'status', 'active' );
+		} finally {
+			remove_filter( 'query', $rotate );
+		}
+
+		$entry = wp_cache_get( md5( 'active' ), $group );
+		$this->assertIsArray( $entry );
+		$this->assertSame( $old, $entry['last_changed'] );
+		$this->assertSame( 'during-read', wp_cache_get( 'last_changed', $group ) );
+		$before = $wpdb->num_queries;
+		$this->assertSame( $id, (int) $query->get_item_by( 'status', 'active' )->id );
+		$this->assertGreaterThan( $before, $wpdb->num_queries );
 	}
 }


### PR DESCRIPTION
Repeated invalidations currently create another persistent key for each secondary `get_item_by()` lookup. Store the primary ID and lookup group generation under a stable value hash, so subsequent lookups replace stale entries instead of accumulating keys.

Capture the generation before the database read and reject entries with missing or stale generations. Remove the unused private key-helper parameter. Preserve per-column invalidation, canonical by-ID object caching, and the existing behavior of uncached misses.

This completes the secondary lookup counterpart to #256. Existing orphaned entries are not removed, and this does not add expiration for distinct lookup values.

Validation:

- PHP 8.1 and 8.2, WordPress 6.7.7, MariaDB 10.2: 1,764 tests / 3,896 assertions passed on each PHP version, including relationship priming and per-column invalidation tests.
- External Redis 7 verification with a test-only adapter: 18 tests / 142 assertions passed. Twenty mutation cycles retain exactly two lookup entries plus one generation key; a fresh cache client resolves the persisted result.
- The Redis key-count check and all three new regression methods fail against the unpatched code.
- Composer strict validation, PHPStan, PHPCS, and diff checks passed.

Props @hellofromahmed for reporting persistent-cache growth in #253.

Fixes #253.
See #256.

