### PR TITLE
Compatibility: preserve selected subclass contracts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Notable changes to BerlinDB are documented here.
 
 ## 3.1.0 - Unreleased
 
+- Preserves selected released subclass signatures for schema accessors, Query
+  helpers, and operator rendering. New schema filtering uses `get_filtered_items()`,
+  `get_filtered_columns()`, and `get_filtered_indexes()`; each filters the result of
+  its released accessor. The two CREATE TABLE string methods share a private
+  `get_create_table_array()` builder for validation and SQL fragments.
+  Column compatibility is limited to APIs predating 3.0: `is_numeric()` retains
+  its parameterless signature, with explicit type checks on `is_numeric_type()`,
+  and `validate_datetime()`, `validate_decimal()`, and `validate_uuid()` remain
+  public. The 3.0-only Column predicates and cast-aware `get_name_sql()` keep their
+  expanded signatures. Cast-aware operator rendering uses `get_sql_with_cast()`.
+  Removed newly added native return types from selected released untyped extension
+  methods while retaining their PHPDoc contracts. The deliberate lifecycle and
+  strict-config changes below remain separate migration requirements.
+
 - Extends the plural write verbs `update_items()` / `delete_items()` to composite-key
   tables (#241, following the singular verbs in #234). A query-var filter now resolves to
   each matched row's FULL primary key - every primary column, not just the first - via the
@@ -563,19 +577,23 @@ Notable changes to BerlinDB are documented here.
   value otherwise. The `{item}_deleted` and `transition_{item}_{key}` action hooks
   now pass `$item_id` as `int|string` (the real key) rather than casting to `int`.
   Both are no-ops for the common `bigint` `auto_increment` case.
-- The `Query::sunrise()` construction hook (3.0.0) is renamed to `Query::init()`,
-  which now runs after `configure()` and before `consume_args()`; `sunrise()` still
-  exists but now runs *before* configuration. Rename any override that derived state
-  from the query's configuration.
+- Query setup moves from `sunrise()` to `init()`, after `configure()` and before
+  `consume_args()`. `sunrise()` already ran before argument processing in 3.0.0;
+  it no longer builds Query's schema, prefixes, shape, and parsers. Move overrides
+  that depend on that setup to `init()`, calling `parent::init()` first. A constructor
+  query now runs AFTER `init()`; an old `init()` override that expected query results
+  should move that work after `parent::consume_args()` or to `sunset()`.
 - The `parse_args()` construction hook (`Boot`/`Query`, 3.0.0) is renamed to
   `consume_args()`; `parse_args()` is now a `wp_parse_args()`-style array helper.
   Rename any override of the leftover-args hook to `consume_args()`.
 - Configuration is strict by default — keys outside the declared config surface
-  (`get_config_callbacks()`) are dropped and logged. Override `is_strict_config()`
+  (`get_config_callbacks()`) are dropped and logged. Declaring a custom property
+  alone does not register it as configuration. Override `is_strict_config()`
   to opt out (as `Row` does for its
   dynamic columns).
 - Several `Parser`/`Column`/`Query` methods introduced in 3.0.0 are now `protected`
-  rather than public.
+  rather than public. The older datetime, decimal, and UUID Column validators stay
+  public. The 3.0.0 visibility changes are intentional extension API changes.
 - Parsers now fail closed (return no rows) on unresolvable or misdeclared columns,
   and no longer bleed clauses across parser types.
 - `update_item()` now returns `true` for a meta-only update whose bulk meta saved
@@ -651,14 +669,15 @@ Notable changes to BerlinDB are documented here.
   same way. The primary cache_key needs no extra index (the primary key already covers
   it). It is a `KEY`, not `UNIQUE`: a cache_key's identity is an application invariant,
   not a database constraint.
-- `Schema::get_items()`, `Schema::get_columns()`, and `Schema::get_indexes()` accept
+- `Schema::get_filtered_items()`, `Schema::get_filtered_columns()`, and
+  `Schema::get_filtered_indexes()` accept
   optional `wp_filter_object_list()` match args, an `'and'`/`'or'`/`'not'` operator, and
   a `$field` to pluck from each match (mirroring `Query::get_columns()`), e.g.
-  `get_columns( array( 'primary' => true ), 'and', 'name' )`. The `type` arg is matched
+  `get_filtered_columns( array( 'primary' => true ), 'and', 'name' )`. The `type` arg is matched
   case-insensitively (Column types are stored uppercase, Index types lowercase). With no
   args and no field the whole collection is returned as before; a filtered or plucked
   result is a reindexed list.
-- `Query::get_columns()` now delegates to the schema object's `get_columns()` rather than
+- `Query::get_columns()` now delegates to the schema object's `get_filtered_columns()` rather than
   resolving columns itself.
 - The schema diff engine now detects **modified** columns and indexes (#224 phase 2b),
   not just added/dropped ones. A same-named column or index defined differently on the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ Notable changes to BerlinDB are documented here.
 - Preserves selected released subclass signatures for schema accessors, Query
   helpers, and operator rendering. New schema filtering uses `get_filtered_items()`,
   `get_filtered_columns()`, and `get_filtered_indexes()`; each filters the result of
-  its released accessor. The two CREATE TABLE string methods share a private
-  `get_create_table_array()` builder for validation and SQL fragments.
+  its released accessor, with a Query fallback for schemas exposing only
+  `get_columns()`. `get_create_table_string()` uses a private
+  `get_create_table_array()` builder and accepts an optional foreign-key flag.
+  Subclasses overriding this 3.0 method must add `bool $with_foreign_keys = false`
+  to their signature.
   Column compatibility is limited to APIs predating 3.0: `is_numeric()` retains
   its parameterless signature, with explicit type checks on `is_numeric_type()`,
   and `validate_datetime()`, `validate_decimal()`, and `validate_uuid()` remain
   public. The 3.0-only Column predicates and cast-aware `get_name_sql()` keep their
-  expanded signatures. Cast-aware operator rendering uses `get_sql_with_cast()`.
+  expanded signatures. Cast-aware operator rendering uses `get_sql_with_cast()`;
+  custom operators must override that method to customize explicit casts.
   Removed newly added native return types from selected released untyped extension
   methods while retaining their PHPDoc contracts. The deliberate lifecycle and
   strict-config changes below remain separate migration requirements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ hand-rolled queries — never more surprising.
    vendor/bin/phpcs
    ```
 5. **Don't invent APIs.** If unsure how something behaves, search `src/` and
-   `tests/` — the source and its 1730 test methods are the source of truth, ahead
+   `tests/` — the source and its 1733 test methods are the source of truth, ahead
    of memory or training data. (PHPUnit reports more cases: data providers expand
    methods at run time.)
 6. **Keep changes focused and tested.** Bug fixes and new behavior ship with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ hand-rolled queries — never more surprising.
    vendor/bin/phpcs
    ```
 5. **Don't invent APIs.** If unsure how something behaves, search `src/` and
-   `tests/` — the source and its 1727 test methods are the source of truth, ahead
+   `tests/` — the source and its 1730 test methods are the source of truth, ahead
    of memory or training data. (PHPUnit reports more cases: data providers expand
    methods at run time.)
 6. **Keep changes focused and tested.** Bug fixes and new behavior ship with

--- a/src/Database/Kern/Column.php
+++ b/src/Database/Kern/Column.php
@@ -1080,10 +1080,22 @@ class Column {
 	 * Consider using is_int() or is_decimal() for improved specificity.
 	 *
 	 * @since 1.0.0
+	 * @return bool True if bit, int, or float.
+	 */
+	public function is_numeric() {
+		return $this->is_numeric_type();
+	}
+
+	/**
+	 * Return if a column type is numeric.
+	 *
+	 * Consider using is_int() or is_decimal() for improved specificity.
+	 *
+	 * @since 3.1.0
 	 * @param string $type Optional type string to test. Defaults to $this->type.
 	 * @return bool True if bit, int, or float.
 	 */
-	public function is_numeric( $type = '' ) {
+	public function is_numeric_type( $type = '' ) {
 		return $this->is_type(
 			array(
 
@@ -1990,7 +2002,7 @@ class Column {
 	 * @param string $value Default ''. A datetime value that needs validating.
 	 * @return string|null A valid datetime value, or null for a nullable column.
 	 */
-	protected function validate_datetime( $value = '' ) {
+	public function validate_datetime( $value = '' ) {
 
 		// Not using the $default yet.
 		$use_default = false;
@@ -2048,7 +2060,7 @@ class Column {
 	 * @param int        $decimals Default 9. The number of decimal points to accept.
 	 * @return float Formatted to the number of decimals specified
 	 */
-	protected function validate_decimal( $value = 0, $decimals = 9 ) {
+	public function validate_decimal( $value = 0, $decimals = 9 ) {
 
 		// Protect against non-numeric decimals.
 		if ( ! is_numeric( $decimals ) ) {
@@ -2144,7 +2156,7 @@ class Column {
 	 * @param string $value The UUID value to validate.
 	 * @return string The original value if valid, or the column default.
 	 */
-	protected function validate_uuid( $value = '' ) {
+	public function validate_uuid( $value = '' ) {
 		$prefix = 'urn:uuid:';
 
 		// Return early if valid UUID string with correct prefix.

--- a/src/Database/Kern/Query.php
+++ b/src/Database/Kern/Query.php
@@ -825,7 +825,7 @@ class Query {
 	 *
 	 * @return string
 	 */
-	public function get_item_name_plural(): string {
+	public function get_item_name_plural() {
 		return (string) $this->item_name_plural;
 	}
 

--- a/src/Database/Kern/Schema.php
+++ b/src/Database/Kern/Schema.php
@@ -442,7 +442,7 @@ class Schema {
 		}
 
 		// Gather the primary-flagged columns.
-		$primary = $this->get_columns( array( 'primary' => true ) );
+		$primary = $this->get_filtered_columns( array( 'primary' => true ) );
 
 		// Derive only for a single primary column; a composite PK must be explicit.
 		if ( 1 !== count( $primary ) ) {
@@ -464,7 +464,7 @@ class Schema {
 	 * @return bool
 	 */
 	private function has_primary_index(): bool {
-		return ! empty( $this->get_indexes( array( 'type' => 'primary' ) ) );
+		return ! empty( $this->get_filtered_indexes( array( 'type' => 'primary' ) ) );
 	}
 
 	/**
@@ -492,7 +492,7 @@ class Schema {
 	 * @since 3.1.0
 	 */
 	private function init_flag_indexes(): void {
-		$flagged = $this->get_columns(
+		$flagged = $this->get_filtered_columns(
 			array(
 				'unique' => true,
 				'index'  => true,
@@ -607,7 +607,7 @@ class Schema {
 	private function init_cache_key_indexes(): void {
 
 		// A cache_key column is looked up by value - index it.
-		foreach ( $this->get_columns( array( 'cache_key' => true ) ) as $column ) {
+		foreach ( $this->get_filtered_columns( array( 'cache_key' => true ) ) as $column ) {
 			$this->add_lookup_key( $column, 'cache_key column', 'cache_key_index_not_indexable' );
 		}
 	}
@@ -853,15 +853,33 @@ class Schema {
 	}
 
 	/**
+	 * Get a schema item collection by type.
+	 *
+	 * @since 3.0.0
+	 * @param string $type Item collection type.
+	 * @return Column[]|Index[]
+	 */
+	public function get_items( $type = 'columns' ) {
+		$type = $this->validate_item_type( $type );
+
+		if ( 'columns' === $type ) {
+			return $this->columns;
+		} elseif ( 'indexes' === $type ) {
+			return $this->indexes;
+		}
+
+		return array();
+	}
+
+	/**
 	 * Get a schema item collection by type, optionally filtered.
 	 *
 	 * With no $args, returns the whole collection. With $args, returns the items whose
 	 * properties match (via WordPress's wp_filter_object_list()) - e.g.
-	 * get_items( 'columns', array( 'primary' => true ) ). A $field plucks that property
+	 * get_filtered_items( 'columns', array( 'primary' => true ) ). A $field plucks that property
 	 * from each match instead of returning the objects. Mirrors Query::get_columns().
 	 *
-	 * @since 3.0.0
-	 * @since 3.1.0 Added $args / $operator filtering and the $field pluck.
+	 * @since 3.1.0
 	 *
 	 * @param string              $type     Item collection type. Accepts 'columns' or
 	 *                                      'indexes' (and their singular aliases).
@@ -877,17 +895,26 @@ class Schema {
 	 *
 	 * @phpstan-return ($field is false ? Column[]|Index[] : list<mixed>)
 	 */
-	public function get_items( $type = 'columns', $args = array(), $operator = 'and', $field = false ) {
+	public function get_filtered_items( $type = 'columns', $args = array(), $operator = 'and', $field = false ) {
 		$type = $this->validate_item_type( $type );
 
-		// Resolve the collection.
-		if ( 'columns' === $type ) {
-			$items = $this->columns;
-		} elseif ( 'indexes' === $type ) {
-			$items = $this->indexes;
-		} else {
-			return array();
-		}
+		$items = $this->get_items( $type );
+
+		return $this->filter_item_collection( $items, $type, $args, $operator, $field );
+	}
+
+	/**
+	 * Filter a collection supplied by a released accessor.
+	 *
+	 * @since 3.1.0
+	 * @param Column[]|Index[] $items Items to filter.
+	 * @param string $type Collection type.
+	 * @param array<string,mixed> $args Property filters.
+	 * @param string $operator Match operator.
+	 * @param bool|string $field Property to return, or false for objects.
+	 * @return Column[]|Index[]|list<mixed>
+	 */
+	private function filter_item_collection( $items, $type, $args, $operator, $field ) {
 
 		// The whole collection when there is nothing to filter or pluck.
 		if ( empty( $args ) && ( false === $field ) ) {
@@ -1249,10 +1276,22 @@ class Schema {
 	}
 
 	/**
-	 * Get all columns in this schema, optionally filtered.
+	 * Get all columns in this schema.
 	 *
 	 * @since 3.0.0
-	 * @since 3.1.0 Added $args / $operator filtering and the $field pluck.
+	 * @return Column[]
+	 */
+	public function get_columns() {
+		/** @var Column[] $items */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		$items = $this->get_items( 'columns' );
+
+		return $items;
+	}
+
+	/**
+	 * Get all columns in this schema, optionally filtered.
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param array<string,mixed> $args     Optional. Property => value match args.
 	 *                                      Default empty (all columns).
@@ -1266,9 +1305,9 @@ class Schema {
 	 *
 	 * @phpstan-return ($field is false ? Column[] : list<mixed>)
 	 */
-	public function get_columns( $args = array(), $operator = 'and', $field = false ) {
+	public function get_filtered_columns( $args = array(), $operator = 'and', $field = false ) {
 		/** @var Column[]|list<mixed> $items */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-		$items = $this->get_items( 'columns', $args, $operator, $field );
+		$items = $this->filter_item_collection( $this->get_columns(), 'columns', $args, $operator, $field );
 
 		return $items;
 	}
@@ -1315,7 +1354,7 @@ class Schema {
 	 * @return string The primary column name, or 'id' if none is flagged.
 	 */
 	public function get_primary_column_name(): string {
-		$primary = $this->get_columns( array( 'primary' => true ) );
+		$primary = $this->get_filtered_columns( array( 'primary' => true ) );
 
 		return ! empty( $primary )
 			? (string) $primary[0]->name
@@ -1424,10 +1463,22 @@ class Schema {
 	}
 
 	/**
-	 * Get all indexes in this schema, optionally filtered.
+	 * Get all indexes in this schema.
 	 *
 	 * @since 3.0.0
-	 * @since 3.1.0 Added $args / $operator filtering and the $field pluck.
+	 * @return Index[]
+	 */
+	public function get_indexes() {
+		/** @var Index[] $items */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		$items = $this->get_items( 'indexes' );
+
+		return $items;
+	}
+
+	/**
+	 * Get all indexes in this schema, optionally filtered.
+	 *
+	 * @since 3.1.0
 	 *
 	 * @param array<string,mixed> $args     Optional. Property => value match args.
 	 *                                      Default empty (all indexes).
@@ -1441,9 +1492,9 @@ class Schema {
 	 *
 	 * @phpstan-return ($field is false ? Index[] : list<mixed>)
 	 */
-	public function get_indexes( $args = array(), $operator = 'and', $field = false ) {
+	public function get_filtered_indexes( $args = array(), $operator = 'and', $field = false ) {
 		/** @var Index[]|list<mixed> $items */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-		$items = $this->get_items( 'indexes', $args, $operator, $field );
+		$items = $this->filter_item_collection( $this->get_indexes(), 'indexes', $args, $operator, $field );
 
 		return $items;
 	}
@@ -1465,7 +1516,7 @@ class Schema {
 
 		// The primary key is addressable as 'primary', whatever its own name.
 		if ( 'primary' === $name ) {
-			$primary = $this->get_indexes( array( 'type' => 'primary' ) );
+			$primary = $this->get_filtered_indexes( array( 'type' => 'primary' ) );
 
 			if ( ! empty( $primary ) ) {
 				return $primary[0];
@@ -1569,24 +1620,42 @@ class Schema {
 	 * independently and in no guaranteed order, so a FK inside CREATE TABLE would
 	 * reference a table that may not exist yet (and MySQL would reject the whole
 	 * create), and two tables could never reference each other. Enforced keys are
-	 * therefore added AFTER the tables exist, via Table::add_foreign_keys(). Pass
-	 * $with_foreign_keys = true only when you control install order (referenced
-	 * tables created first, no cycles) and want the constraint inline.
+	 * therefore added AFTER the tables exist, via Table::add_foreign_keys(). Use
+	 * get_create_table_string_with_foreign_keys() only when you control install
+	 * order and want the constraints inline.
 	 *
 	 * @since 3.0.0
-	 * @since 3.1.0 Optionally emits FOREIGN KEY fragments for enforced relationships.
-	 *
-	 * @param bool $with_foreign_keys Include enforced FK fragments inline. Default
-	 *                                false (deferred); requires controlled install
-	 *                                order when true.
 	 *
 	 * @return string SQL body string, or empty string if invalid or empty.
 	 */
-	public function get_create_table_string( bool $with_foreign_keys = false ) {
+	public function get_create_table_string() {
+		return implode( ",\n", $this->get_create_table_array() );
+	}
+
+	/**
+	 * Get the CREATE TABLE body with enforced foreign keys included.
+	 *
+	 * Call only when referenced tables already exist and install order is known.
+	 *
+	 * @since 3.1.0
+	 * @return string
+	 */
+	public function get_create_table_string_with_foreign_keys() {
+		return implode( ",\n", $this->get_create_table_array( true ) );
+	}
+
+	/**
+	 * Build the validated CREATE TABLE body fragments.
+	 *
+	 * @since 3.1.0
+	 * @param bool $with_foreign_keys Include enforced foreign-key fragments.
+	 * @return string[] Non-empty SQL fragments, or an empty array if invalid.
+	 */
+	private function get_create_table_array( bool $with_foreign_keys = false ): array {
 
 		// Bail if schema has validation errors.
 		if ( ! $this->is_valid() ) {
-			return '';
+			return array();
 		}
 
 		// Columns and indexes always.
@@ -1595,15 +1664,12 @@ class Schema {
 			$this->get_items_create_string( 'indexes' ),
 		);
 
-		// Enforced foreign keys only when opted in (deferred by default).
+		// Foreign keys only when the caller controls installation order.
 		if ( true === $with_foreign_keys ) {
 			$strings = array_merge( $strings, $this->get_foreign_key_strings() );
 		}
 
-		// Join non-empty fragments.
-		$retval = implode( ",\n", array_filter( $strings ) );
-
-		return $retval;
+		return array_values( array_filter( $strings ) );
 	}
 
 	/**
@@ -1611,7 +1677,7 @@ class Schema {
 	 *
 	 * One fragment per enforced, owning-side (belongs_to) relationship, each with
 	 * its remote table resolved from the relationship's remote Query class. Shared
-	 * by get_create_table_string() (emitted inside CREATE TABLE) and
+	 * by get_create_table_array() (emitted inside CREATE TABLE) and
 	 * Table::add_foreign_keys() (emitted as ALTER TABLE ADD). Empty when nothing is
 	 * enforced. Non-enforced relationships stay application-level and emit nothing.
 	 *

--- a/src/Database/Kern/Schema.php
+++ b/src/Database/Kern/Schema.php
@@ -1620,28 +1620,18 @@ class Schema {
 	 * independently and in no guaranteed order, so a FK inside CREATE TABLE would
 	 * reference a table that may not exist yet (and MySQL would reject the whole
 	 * create), and two tables could never reference each other. Enforced keys are
-	 * therefore added AFTER the tables exist, via Table::add_foreign_keys(). Use
-	 * get_create_table_string_with_foreign_keys() only when you control install
-	 * order and want the constraints inline.
+	 * therefore added AFTER the tables exist, via Table::add_foreign_keys(). Pass
+	 * $with_foreign_keys = true only when you control install order and want the
+	 * constraints inline.
 	 *
 	 * @since 3.0.0
+	 * @since 3.1.0 Added the optional foreign-key flag.
 	 *
+	 * @param bool $with_foreign_keys Include enforced foreign keys inline.
 	 * @return string SQL body string, or empty string if invalid or empty.
 	 */
-	public function get_create_table_string() {
-		return implode( ",\n", $this->get_create_table_array() );
-	}
-
-	/**
-	 * Get the CREATE TABLE body with enforced foreign keys included.
-	 *
-	 * Call only when referenced tables already exist and install order is known.
-	 *
-	 * @since 3.1.0
-	 * @return string
-	 */
-	public function get_create_table_string_with_foreign_keys() {
-		return implode( ",\n", $this->get_create_table_array( true ) );
+	public function get_create_table_string( bool $with_foreign_keys = false ) {
+		return implode( ",\n", $this->get_create_table_array( $with_foreign_keys ) );
 	}
 
 	/**

--- a/src/Database/Operators/Comparisons/IsNotNull.php
+++ b/src/Database/Operators/Comparisons/IsNotNull.php
@@ -94,11 +94,10 @@ class IsNotNull extends Base {
 	 * @param Column $col   The column being compared.
 	 * @param string $alias Optional. Table alias for the column reference.
 	 * @param mixed  $value Unused. Unary operators take no value.
-	 * @param string $cast  Unused. A NULL test never casts.
 	 *
 	 * @return string The `{column} IS NOT NULL` expression.
 	 */
-	public function get_sql( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+	public function get_sql( Column $col, string $alias = '', $value = null ): string {
 		return $col->get_name_sql( $alias ) . ' ' . $this->get_sql_compare();
 	}
 
@@ -114,5 +113,19 @@ class IsNotNull extends Base {
 	 */
 	public function get_value_sql( $value = null, $pattern = '%s' ) {
 		return '';
+	}
+
+	/**
+	 * Render this value-free comparison through its specialized renderer.
+	 *
+	 * @since 3.1.0
+	 * @param Column $col Schema column.
+	 * @param string $alias Table alias.
+	 * @param mixed $value Unused value.
+	 * @param string $cast Unused cast.
+	 * @return string
+	 */
+	public function get_sql_with_cast( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+		return $this->get_sql( $col, $alias, $value );
 	}
 }

--- a/src/Database/Operators/Comparisons/IsNull.php
+++ b/src/Database/Operators/Comparisons/IsNull.php
@@ -88,11 +88,10 @@ class IsNull extends Base {
 	 * @param Column $col   The column being compared.
 	 * @param string $alias Optional. Table alias for the column reference.
 	 * @param mixed  $value Unused. Unary operators take no value.
-	 * @param string $cast  Unused. A NULL test never casts.
 	 *
 	 * @return string The `{column} IS NULL` expression.
 	 */
-	public function get_sql( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+	public function get_sql( Column $col, string $alias = '', $value = null ): string {
 		return $col->get_name_sql( $alias ) . ' ' . $this->get_sql_compare();
 	}
 
@@ -111,5 +110,19 @@ class IsNull extends Base {
 	 */
 	public function get_value_sql( $value = null, $pattern = '%s' ) {
 		return '';
+	}
+
+	/**
+	 * Render this value-free comparison through its specialized renderer.
+	 *
+	 * @since 3.1.0
+	 * @param Column $col Schema column.
+	 * @param string $alias Table alias.
+	 * @param mixed $value Unused value.
+	 * @param string $cast Unused cast.
+	 * @return string
+	 */
+	public function get_sql_with_cast( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+		return $this->get_sql( $col, $alias, $value );
 	}
 }

--- a/src/Database/Parsers/Relationship.php
+++ b/src/Database/Parsers/Relationship.php
@@ -1284,6 +1284,6 @@ class Relationship extends Base {
 		 * returns a string; a value-less operator (e.g. NOT EXISTS) yields '',
 		 * which build_conditions() drops as "produced nothing".
 		 */
-		return $operator->get_sql( $column_object, $alias, $value, $cast );
+		return $operator->get_sql_with_cast( $column_object, $alias, $value, $cast );
 	}
 }

--- a/src/Database/Parsers/Relationship.php
+++ b/src/Database/Parsers/Relationship.php
@@ -1280,7 +1280,7 @@ class Relationship extends Base {
 		}
 
 		/*
-		 * Build the comparison SQL against the joined alias. get_sql() always
+		 * Build the comparison SQL against the joined alias. get_sql_with_cast() always
 		 * returns a string; a value-less operator (e.g. NOT EXISTS) yields '',
 		 * which build_conditions() drops as "produced nothing".
 		 */

--- a/src/Database/Traits/Error.php
+++ b/src/Database/Traits/Error.php
@@ -51,7 +51,7 @@ trait Error {
 	 * @param mixed $result Optional. Default false. Any value to check.
 	 * @return bool
 	 */
-	protected function is_success( $result = false ): bool {
+	protected function is_success( $result = false ) {
 
 		// Default return value.
 		$retval = false;

--- a/src/Database/Traits/Operator.php
+++ b/src/Database/Traits/Operator.php
@@ -345,6 +345,10 @@ trait Operator {
 	/**
 	 * Generate an expression with an optional column cast.
 	 *
+	 * Without a cast, dispatches through the released get_sql() hook. Explicit
+	 * casts use the comparison renderer; subclasses with custom cast semantics
+	 * must override this method as well as get_sql().
+	 *
 	 * @since 3.1.0
 	 * @param Column $col Schema column.
 	 * @param string $alias Table alias.

--- a/src/Database/Traits/Operator.php
+++ b/src/Database/Traits/Operator.php
@@ -330,6 +330,35 @@ trait Operator {
 	}
 
 	/**
+	 * Generate the SQL WHERE expression for this operator.
+	 *
+	 * @since 3.0.0
+	 * @param Column $col Schema column.
+	 * @param string $alias Table alias.
+	 * @param mixed $value Value to compare.
+	 * @return string
+	 */
+	public function get_sql( Column $col, string $alias = '', $value = null ): string {
+		return $this->get_comparison_sql( $col, $alias, $value, '' );
+	}
+
+	/**
+	 * Generate an expression with an optional column cast.
+	 *
+	 * @since 3.1.0
+	 * @param Column $col Schema column.
+	 * @param string $alias Table alias.
+	 * @param mixed $value Value to compare.
+	 * @param string $cast SQL cast type.
+	 * @return string
+	 */
+	public function get_sql_with_cast( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+		return ( '' === $cast )
+			? $this->get_sql( $col, $alias, $value )
+			: $this->get_comparison_sql( $col, $alias, $value, $cast );
+	}
+
+	/**
 	 * Generate the full SQL WHERE expression for this operator.
 	 *
 	 * Assembles "{column} {compare} {value}" using the Column's own SQL
@@ -338,7 +367,7 @@ trait Operator {
 	 * callers do not need to supply it separately. Returns an empty string when
 	 * get_value_sql() returns '' (e.g. NOT EXISTS).
 	 *
-	 * @since 3.0.0
+	 * @since 3.1.0
 	 *
 	 * @param Column $col   The schema column providing its name, alias, and pattern.
 	 * @param string $alias Optional. Table alias to prefix the column reference. Default empty.
@@ -347,7 +376,7 @@ trait Operator {
 	 *
 	 * @return string Full SQL expression, or empty string when not applicable.
 	 */
-	public function get_sql( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
+	private function get_comparison_sql( Column $col, string $alias = '', $value = null, string $cast = '' ): string {
 
 		/*
 		 * Derive the pattern from the column, folding the cast: a cast column side

--- a/src/Database/Traits/Parser.php
+++ b/src/Database/Traits/Parser.php
@@ -1247,7 +1247,7 @@ trait Parser {
 
 					// Bare key + bare value: the ordinary operator value path (unchanged).
 				} else {
-					$expr = $operator->get_sql( $col, $alias, $value, $cast );
+					$expr = $operator->get_sql_with_cast( $col, $alias, $value, $cast );
 				}
 			}
 

--- a/src/Database/Traits/Query/Columns.php
+++ b/src/Database/Traits/Query/Columns.php
@@ -183,9 +183,10 @@ trait Columns {
 	/**
 	 * Get columns from the schema, optionally filtered.
 	 *
-	 * Delegates to the schema object's get_columns(): $args and $operator filter the
-	 * columns via wp_filter_object_list() (the schema normalizes a `type` arg to the
-	 * stored uppercase), and $field plucks a property from each match.
+	 * Delegates to the schema object's get_filtered_columns(), falling back to
+	 * get_columns() with local filtering for released schema classes. Both paths
+	 * use $args and $operator to filter, normalize a `type` arg to uppercase, and
+	 * use $field to pluck a property from each match.
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0
@@ -199,15 +200,27 @@ trait Columns {
 	 */
 	public function get_columns( $args = array(), $operator = 'and', $field = false ) {
 
-		// Without a schema there are no columns to return.
-		if ( ! is_callable( array( $this->schema_object, 'get_filtered_columns' ) ) ) {
+		// Prefer the schema's filtering implementation when available.
+		if ( is_callable( array( $this->schema_object, 'get_filtered_columns' ) ) ) {
+			return $this->schema_object->get_filtered_columns( $args, $operator, $field );
+		}
+
+		// Released schema classes may expose only the unfiltered accessor.
+		if ( ! is_callable( array( $this->schema_object, 'get_columns' ) ) ) {
 			return array();
 		}
 
-		/** @var Column[]|list<mixed> $columns */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-		$columns = $this->schema_object->get_filtered_columns( $args, $operator, $field );
+		$columns = $this->schema_object->get_columns();
+		if ( empty( $args ) && ( false === $field ) ) {
+			return $columns;
+		}
 
-		return $columns;
+		// Match the stored column type case, as Schema's filtered accessor does.
+		if ( isset( $args['type'] ) && is_string( $args['type'] ) ) {
+			$args['type'] = strtoupper( $args['type'] );
+		}
+
+		return array_values( wp_filter_object_list( $columns, $args, $operator, $field ) );
 	}
 
 	/**

--- a/src/Database/Traits/Query/Columns.php
+++ b/src/Database/Traits/Query/Columns.php
@@ -189,7 +189,7 @@ trait Columns {
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0
-	 * @since 3.1.0 Delegates to Schema::get_columns(); dropped the legacy inline-$columns source.
+	 * @since 3.1.0 Delegates to Schema::get_filtered_columns(); dropped the legacy inline-$columns source.
 	 *
 	 * @param array<string,mixed> $args     Arguments to filter columns by.
 	 * @param string              $operator Optional. The logical operation to perform.
@@ -197,15 +197,15 @@ trait Columns {
 	 *                                      instead of the entire object. Default false.
 	 * @return Column[]|list<mixed> Array of Column objects, or field values if $field is set.
 	 */
-	public function get_columns( $args = array(), $operator = 'and', $field = false ): array {
+	public function get_columns( $args = array(), $operator = 'and', $field = false ) {
 
 		// Without a schema there are no columns to return.
-		if ( ! is_callable( array( $this->schema_object, 'get_columns' ) ) ) {
+		if ( ! is_callable( array( $this->schema_object, 'get_filtered_columns' ) ) ) {
 			return array();
 		}
 
 		/** @var Column[]|list<mixed> $columns */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-		$columns = $this->schema_object->get_columns( $args, $operator, $field );
+		$columns = $this->schema_object->get_filtered_columns( $args, $operator, $field );
 
 		return $columns;
 	}
@@ -265,7 +265,7 @@ trait Columns {
 	 * @param bool   $alias Whether to include the table alias prefix.
 	 * @return string
 	 */
-	protected function get_column_name_aliased( $column_name = '', $alias = true ): string {
+	protected function get_column_name_aliased( $column_name = '', $alias = true ) {
 
 		// Default return value.
 		$retval = $column_name;
@@ -292,7 +292,7 @@ trait Columns {
 	 * @param bool   $alias Whether to include the table alias prefix.
 	 * @return string
 	 */
-	public function get_quoted_column_name_aliased( $column_name = '', $alias = true ): string {
+	public function get_quoted_column_name_aliased( $column_name = '', $alias = true ) {
 
 		// Default to the primary column when no name is given.
 		if ( '' === $column_name ) {
@@ -342,7 +342,7 @@ trait Columns {
 	 *
 	 * @return string Escaped/prepared SQL, possibly wrapped in parenthesis.
 	 */
-	public function get_in_sql( $column_name = '', $values = array(), $wrap = true, $pattern = '' ): string {
+	public function get_in_sql( $column_name = '', $values = array(), $wrap = true, $pattern = '' ) {
 
 		// Bail if no values or invalid column.
 		if ( empty( $values ) || ! $this->is_valid_column( $column_name ) ) {

--- a/src/Database/Traits/Query/Variables.php
+++ b/src/Database/Traits/Query/Variables.php
@@ -104,7 +104,7 @@ trait Variables {
 	 * @param string $key Query variable key.
 	 * @return bool
 	 */
-	public function is_query_var_default( $key = '' ): bool {
+	public function is_query_var_default( $key = '' ) {
 		return ( $this->get_query_var( $key ) === $this->query_var_default_value );
 	}
 

--- a/src/Database/Traits/Storage/Table/Alter.php
+++ b/src/Database/Traits/Storage/Table/Alter.php
@@ -134,7 +134,7 @@ trait Alter {
 	 * Add this schema's enforced foreign keys to the table, via ALTER TABLE.
 	 *
 	 * The deferred counterpart to emitting foreign keys inside CREATE TABLE (see
-	 * Schema::get_create_table_string()): use this when the referenced tables were
+	 * Schema::get_create_table_string( true )): use this when the referenced tables were
 	 * not guaranteed to exist at create time, or for two tables that reference each
 	 * other - create both first, then add the keys. Only enforced (enforce => true)
 	 * relationships emit anything; a schema with none is a no-op success. Each key

--- a/tests/Database/Kern/Schema/SchemaFilteredAccessorTest.php
+++ b/tests/Database/Kern/Schema/SchemaFilteredAccessorTest.php
@@ -2,7 +2,7 @@
 /**
  * Schema filtered-accessor tests.
  *
- * Schema::get_items() (and the get_columns() / get_indexes() that thin over it) accept
+ * Schema::get_filtered_items() (and the get_filtered_columns() / get_filtered_indexes() that thin over it) accept
  * wp_filter_object_list() match args: a property => value array plus an 'and' / 'or' /
  * 'not' operator. The `type` arg is normalized to each collection's stored case (Column
  * types are uppercase, Index types lowercase) so a caller may pass either.
@@ -21,7 +21,7 @@ use BerlinDB\Database\Kern\Schema;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for the filtered get_items() / get_columns() / get_indexes() accessors.
+ * Tests for the get_filtered_items() / get_filtered_columns() / get_filtered_indexes() accessors.
  *
  * @since 3.1.0
  */
@@ -105,7 +105,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_filters_by_boolean_flag() {
-		$columns = $this->schema()->get_columns( array( 'primary' => true ) );
+		$columns = $this->schema()->get_filtered_columns( array( 'primary' => true ) );
 
 		$this->assertSame( array( 'id' ), $this->names( $columns ) );
 	}
@@ -116,7 +116,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_or_operator_matches_any_flag() {
-		$columns = $this->schema()->get_columns(
+		$columns = $this->schema()->get_filtered_columns(
 			array(
 				'unique' => true,
 				'index'  => true,
@@ -133,7 +133,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_not_operator_excludes_matches() {
-		$columns = $this->schema()->get_columns(
+		$columns = $this->schema()->get_filtered_columns(
 			array(
 				'unique' => true,
 				'index'  => true,
@@ -151,7 +151,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_type_arg_is_case_normalized() {
-		$columns = $this->schema()->get_columns( array( 'type' => 'varchar' ) );
+		$columns = $this->schema()->get_filtered_columns( array( 'type' => 'varchar' ) );
 
 		$this->assertSame( array( 'email', 'slug', 'token' ), $this->names( $columns ) );
 	}
@@ -162,7 +162,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_no_match_returns_empty_array() {
-		$columns = $this->schema()->get_columns( array( 'name' => 'nonexistent' ) );
+		$columns = $this->schema()->get_filtered_columns( array( 'name' => 'nonexistent' ) );
 
 		$this->assertSame( array(), $columns );
 	}
@@ -173,7 +173,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_filtered_result_is_a_list() {
-		$columns = $this->schema()->get_columns( array( 'type' => 'varchar' ) );
+		$columns = $this->schema()->get_filtered_columns( array( 'type' => 'varchar' ) );
 
 		$this->assertSame( array( 0, 1, 2 ), array_keys( $columns ) );
 	}
@@ -184,7 +184,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_indexes_filters_by_type() {
-		$indexes = $this->schema()->get_indexes( array( 'type' => 'unique' ) );
+		$indexes = $this->schema()->get_filtered_indexes( array( 'type' => 'unique' ) );
 
 		$this->assertSame( array( 'email' ), $this->names( $indexes ) );
 		$this->assertContainsOnlyInstancesOf( Index::class, $indexes );
@@ -196,30 +196,30 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_indexes_type_arg_is_case_normalized() {
-		$indexes = $this->schema()->get_indexes( array( 'type' => 'PRIMARY' ) );
+		$indexes = $this->schema()->get_filtered_indexes( array( 'type' => 'PRIMARY' ) );
 
 		$this->assertCount( 1, $indexes );
 		$this->assertSame( 'primary', strtolower( $indexes[0]->type ) );
 	}
 
 	/**
-	 * get_items() applies the same filtering for the columns collection.
+	 * get_filtered_items() applies the same filtering for the columns collection.
 	 *
 	 * @since 3.1.0
 	 */
 	public function test_get_items_columns_filters() {
-		$items = $this->schema()->get_items( 'columns', array( 'primary' => true ) );
+		$items = $this->schema()->get_filtered_items( 'columns', array( 'primary' => true ) );
 
 		$this->assertSame( array( 'id' ), $this->names( $items ) );
 	}
 
 	/**
-	 * get_items() accepts the singular 'column' alias with filter args.
+	 * get_filtered_items() accepts the singular 'column' alias with filter args.
 	 *
 	 * @since 3.1.0
 	 */
 	public function test_get_items_singular_alias_filters() {
-		$items = $this->schema()->get_items( 'column', array( 'unique' => true ) );
+		$items = $this->schema()->get_filtered_items( 'column', array( 'unique' => true ) );
 
 		$this->assertSame( array( 'email' ), $this->names( $items ) );
 	}
@@ -230,7 +230,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_items_unknown_type_returns_empty_with_args() {
-		$items = $this->schema()->get_items( 'bogus', array( 'primary' => true ) );
+		$items = $this->schema()->get_filtered_items( 'bogus', array( 'primary' => true ) );
 
 		$this->assertSame( array(), $items );
 	}
@@ -241,7 +241,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_field_plucks_property_from_all() {
-		$names = $this->schema()->get_columns( array(), 'and', 'name' );
+		$names = $this->schema()->get_filtered_columns( array(), 'and', 'name' );
 
 		$this->assertSame( array( 'id', 'email', 'slug', 'token' ), $names );
 	}
@@ -252,7 +252,7 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_columns_field_plucks_from_filtered_matches() {
-		$names = $this->schema()->get_columns( array( 'type' => 'varchar' ), 'and', 'name' );
+		$names = $this->schema()->get_filtered_columns( array( 'type' => 'varchar' ), 'and', 'name' );
 
 		$this->assertSame( array( 'email', 'slug', 'token' ), $names );
 	}
@@ -263,18 +263,18 @@ class SchemaFilteredAccessorTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_get_indexes_field_plucks_property() {
-		$names = $this->schema()->get_indexes( array( 'type' => 'unique' ), 'and', 'name' );
+		$names = $this->schema()->get_filtered_indexes( array( 'type' => 'unique' ), 'and', 'name' );
 
 		$this->assertSame( array( 'email' ), $names );
 	}
 
 	/**
-	 * get_items() plucks a field for the resolved collection.
+	 * get_filtered_items() plucks a field for the resolved collection.
 	 *
 	 * @since 3.1.0
 	 */
 	public function test_get_items_field_plucks_property() {
-		$names = $this->schema()->get_items( 'columns', array( 'primary' => true ), 'and', 'name' );
+		$names = $this->schema()->get_filtered_items( 'columns', array( 'primary' => true ), 'and', 'name' );
 
 		$this->assertSame( array( 'id' ), $names );
 	}

--- a/tests/Database/Kern/Schema/SchemaForeignKeyTest.php
+++ b/tests/Database/Kern/Schema/SchemaForeignKeyTest.php
@@ -153,7 +153,13 @@ class SchemaForeignKeyTest extends TestCase {
 	 * @since 3.1.0
 	 */
 	public function test_create_table_string_includes_the_foreign_key_when_opted_in() {
-		$sql = $this->schema_with_relationship( true )->get_create_table_string( true );
+		$schema = $this->schema_with_relationship( true );
+		$sql    = $schema->get_create_table_string_with_foreign_keys();
+
+		$this->assertSame(
+			$schema->get_create_table_string() . ",\n" . implode( ",\n", $schema->get_foreign_key_strings() ),
+			$sql
+		);
 
 		$this->assertStringContainsString( 'FOREIGN KEY', $sql );
 		$this->assertStringContainsString( '`widget_id`', $sql );

--- a/tests/Database/Kern/Schema/SchemaForeignKeyTest.php
+++ b/tests/Database/Kern/Schema/SchemaForeignKeyTest.php
@@ -3,7 +3,7 @@
  * Enforced foreign-key DDL emission (#205 / #193 Phase 5).
  *
  * An enforced belongs_to relationship now emits a FOREIGN KEY fragment - inside
- * CREATE TABLE (Schema::get_create_table_string()) and as a reusable list
+ * CREATE TABLE (Schema::get_create_table_string( true )) and as a reusable list
  * (get_foreign_key_strings()), with the remote table resolved from the remote
  * Query class. These are integration tests: resolving the remote name needs the
  * remote table registered on $wpdb, which constructing a TestTable does.
@@ -154,7 +154,7 @@ class SchemaForeignKeyTest extends TestCase {
 	 */
 	public function test_create_table_string_includes_the_foreign_key_when_opted_in() {
 		$schema = $this->schema_with_relationship( true );
-		$sql    = $schema->get_create_table_string_with_foreign_keys();
+		$sql    = $schema->get_create_table_string( true );
 
 		$this->assertSame(
 			$schema->get_create_table_string() . ",\n" . implode( ",\n", $schema->get_foreign_key_strings() ),

--- a/tests/Database/Kern/Table/TableForeignKeyTest.php
+++ b/tests/Database/Kern/Table/TableForeignKeyTest.php
@@ -105,6 +105,11 @@ class FkChildTable extends Table {
 	protected $engine  = 'InnoDB';
 }
 
+/** Referencing table with constraints emitted during creation. */
+class FkInlineChildTable extends FkChildTable {
+	protected $foreign_keys = 'inline';
+}
+
 /**
  * Runtime integration tests for Table::add_foreign_keys().
  *
@@ -182,6 +187,31 @@ class TableForeignKeyTest extends TestCase {
 			$wpdb->prefix . 'berlindb_fk_parent_test',
 			$constraints[0]->REFERENCED_TABLE_NAME
 		);
+	}
+
+	/**
+	 * The inline mode sends foreign keys through the table creation path.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_inline_creation_emits_foreign_keys(): void {
+		$table   = new FkInlineChildTable();
+		$sql     = '';
+		$capture = static function ( $query ) use ( &$sql ) {
+			if ( 0 === strpos( $query, 'CREATE ' ) ) {
+				$sql = $query;
+				return 'SELECT 1';
+			}
+			return $query;
+		};
+		add_filter( 'query', $capture );
+		try {
+			$table->create();
+		} finally {
+			remove_filter( 'query', $capture );
+		}
+		$this->assertStringContainsString( 'FOREIGN KEY', $sql );
+		$this->assertStringContainsString( '`parent_id`', $sql );
 	}
 
 	/**

--- a/tests/Database/Operators/OperatorsTest.php
+++ b/tests/Database/Operators/OperatorsTest.php
@@ -746,7 +746,7 @@ class OperatorsTest extends TestCase {
 				'type' => 'varchar',
 			)
 		);
-		$sql = ( new Equal() )->get_sql( $col, 't', '100', 'SIGNED' );
+		$sql = ( new Equal() )->get_sql_with_cast( $col, 't', '100', 'SIGNED' );
 		$this->assertStringContainsString( 'CAST(`t`.`total` AS SIGNED)', $sql );
 	}
 
@@ -1023,7 +1023,7 @@ class OperatorsTest extends TestCase {
 				'type' => 'varchar',
 			)
 		);
-		$sql = ( new In() )->get_sql( $col, 't', array( '1', '2' ), 'SIGNED' );
+		$sql = ( new In() )->get_sql_with_cast( $col, 't', array( '1', '2' ), 'SIGNED' );
 		$this->assertStringContainsString( 'CAST(`t`.`total` AS SIGNED)', $sql );
 		$this->assertStringContainsStringIgnoringCase( 'IN', $sql );
 	}

--- a/tests/Database/ReleasedSubclassContractTest.php
+++ b/tests/Database/ReleasedSubclassContractTest.php
@@ -55,16 +55,6 @@ class ReleasedSchemaOverrides extends TestSchema {
 	public function get_indexes() {
 		return parent::get_indexes();
 	}
-
-	/**
-	 * Supply custom DDL through the released hook.
-	 *
-	 * @since 3.1.0
-	 * @return string
-	 */
-	public function get_create_table_string() {
-		return '`custom` bigint';
-	}
 }
 
 /**
@@ -128,6 +118,35 @@ class ReleasedQueryOverrides extends TestQuery {
 }
 
 /**
+ * A schema exposing only the released column accessor.
+ *
+ * @since 3.1.0
+ */
+class ReleasedColumnsOnlySchema {
+
+	/**
+	 * Get columns without requiring inheritance from Schema.
+	 *
+	 * @since 3.1.0
+	 * @return Column[]
+	 */
+	public function get_columns() {
+		return ( new TestSchema() )->get_columns();
+	}
+}
+
+/**
+ * A query declaring a schema through its released property.
+ *
+ * @since 3.1.0
+ */
+class ReleasedColumnsOnlyQuery extends TestQuery {
+
+	/** @var string */
+	protected $table_schema = ReleasedColumnsOnlySchema::class;
+}
+
+/**
  * An operator using the released rendering signature.
  *
  * @since 3.1.0
@@ -185,6 +204,33 @@ class ReleasedSubclassContractTest extends TestCase {
 		$this->assertSame( 'CAST(`total` AS SIGNED)', $column->get_name_sql( '', 'SIGNED' ) );
 		$this->assertSame( 'custom = 1', ( new ReleasedOperatorOverride() )->get_sql_with_cast( $column, '', 1 ) );
 		$this->assertNotEmpty( ( new ReleasedQueryOverrides() )->get_columns() );
+	}
+
+	/**
+	 * A released schema object supports filtering without the new accessor.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_query_accepts_columns_only_schema(): void {
+		$query = new ReleasedColumnsOnlyQuery();
+		$this->assertNotEmpty( $query->get_columns() );
+		$this->assertSame( array( 'status' ), $query->get_columns( array( 'name' => 'status' ), 'and', 'name' ) );
+		$this->assertSame( array(), $query->get_columns( array( 'name' => 'missing' ) ) );
+	}
+
+	/**
+	 * Explicit casts use the cast-aware renderer rather than the released hook.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_casts_use_cast_aware_renderer(): void {
+		$column = new Column(
+			array(
+				'name' => 'total',
+				'type' => 'int',
+			)
+		);
+		$this->assertSame( 'CAST(`total` AS SIGNED) = 1', ( new ReleasedOperatorOverride() )->get_sql_with_cast( $column, '', 1, 'SIGNED' ) );
 	}
 
 	/**

--- a/tests/Database/ReleasedSubclassContractTest.php
+++ b/tests/Database/ReleasedSubclassContractTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Released extension signatures and override dispatch.
+ *
+ * @package BerlinDB\Tests
+ * @since 3.1.0
+ */
+
+namespace BerlinDB\Tests;
+
+use BerlinDB\Database\Kern\Column;
+use BerlinDB\Database\Operators\Comparisons\Equal;
+use BerlinDB\Tests\Fixtures\TestQuery;
+use BerlinDB\Tests\Fixtures\TestSchema;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * A schema using the signatures shipped in 3.0.0.
+ *
+ * @since 3.1.0
+ */
+class ReleasedSchemaOverrides extends TestSchema {
+
+	/** @var int */
+	public $column_reads = 0;
+
+	/**
+	 * Get items through the released collection hook.
+	 *
+	 * @since 3.1.0
+	 * @param string $type Collection type.
+	 * @return array
+	 */
+	public function get_items( $type = 'columns' ) {
+		return parent::get_items( $type );
+	}
+
+	/**
+	 * Count column reads through the released hook.
+	 *
+	 * @since 3.1.0
+	 * @return array
+	 */
+	public function get_columns() {
+		++$this->column_reads;
+		return parent::get_columns();
+	}
+
+	/**
+	 * Get indexes through the released hook.
+	 *
+	 * @since 3.1.0
+	 * @return array
+	 */
+	public function get_indexes() {
+		return parent::get_indexes();
+	}
+
+	/**
+	 * Supply custom DDL through the released hook.
+	 *
+	 * @since 3.1.0
+	 * @return string
+	 */
+	public function get_create_table_string() {
+		return '`custom` bigint';
+	}
+}
+
+/**
+ * A column retaining the extension signatures that predate 3.0.0.
+ *
+ * @since 3.1.0
+ */
+class ReleasedColumnOverrides extends Column {
+
+	/**
+	 * Preserve the released predicate override.
+	 *
+	 * @since 3.1.0
+	 * @return bool
+	 */
+	public function is_numeric() {
+		return parent::is_numeric();
+	}
+
+	/**
+	 * Preserve the released success check override.
+	 *
+	 * @since 3.1.0
+	 * @param mixed $value Result to check.
+	 * @return bool
+	 */
+	protected function is_success( $value = false ) {
+		return parent::is_success( $value );
+	}
+}
+
+/**
+ * A query with untyped released overrides.
+ *
+ * @since 3.1.0
+ */
+class ReleasedQueryOverrides extends TestQuery {
+
+	/**
+	 * Keep the released untyped signature.
+	 *
+	 * @since 3.1.0
+	 * @param array $args Filters.
+	 * @param string $operator Match logic.
+	 * @param bool|string $field Field to return.
+	 * @return array
+	 */
+	public function get_columns( $args = array(), $operator = 'and', $field = false ) {
+		return parent::get_columns( $args, $operator, $field );
+	}
+
+	/**
+	 * Keep the released untyped signature.
+	 *
+	 * @since 3.1.0
+	 * @return string
+	 */
+	public function get_item_name_plural() {
+		return parent::get_item_name_plural();
+	}
+}
+
+/**
+ * An operator using the released rendering signature.
+ *
+ * @since 3.1.0
+ */
+class ReleasedOperatorOverride extends Equal {
+
+	/**
+	 * Supply a custom expression through the released hook.
+	 *
+	 * @since 3.1.0
+	 * @param Column $col Schema column.
+	 * @param string $alias Table alias.
+	 * @param mixed $value Value to compare.
+	 * @return string
+	 */
+	public function get_sql( Column $col, string $alias = '', $value = null ): string {
+		return 'custom = 1';
+	}
+}
+
+/**
+ * Check extension loading and dispatch, not only reflection signatures.
+ *
+ * @since 3.1.0
+ */
+class ReleasedSubclassContractTest extends TestCase {
+
+	/**
+	 * New schema helpers preserve the released override points.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_filtered_schema_reads_honor_released_overrides(): void {
+		$schema = new ReleasedSchemaOverrides();
+		$before = $schema->column_reads;
+
+		$columns = $schema->get_filtered_columns( array( 'name' => 'status' ) );
+		$this->assertCount( 1, $columns );
+		$this->assertSame( 'status', $columns[0]->name );
+		$this->assertGreaterThan( $before, $schema->column_reads );
+	}
+
+	/**
+	 * Column casts still work and operator helpers retain the released renderer.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_sql_helpers_honor_released_overrides(): void {
+		$column = new ReleasedColumnOverrides(
+			array(
+				'name' => 'total',
+				'type' => 'int',
+			)
+		);
+		$this->assertSame( 'CAST(`total` AS SIGNED)', $column->get_name_sql( '', 'SIGNED' ) );
+		$this->assertSame( 'custom = 1', ( new ReleasedOperatorOverride() )->get_sql_with_cast( $column, '', 1 ) );
+		$this->assertNotEmpty( ( new ReleasedQueryOverrides() )->get_columns() );
+	}
+
+	/**
+	 * Validators that predate 3.0 remain callable by plugins.
+	 *
+	 * @since 3.1.0
+	 */
+	public function test_older_validators_remain_public(): void {
+		$column = new Column(
+			array(
+				'name' => 'value',
+				'type' => 'varchar',
+			)
+		);
+		foreach ( array( 'validate_datetime', 'validate_decimal', 'validate_uuid' ) as $method ) {
+			$this->assertTrue( is_callable( array( $column, $method ) ) );
+		}
+	}
+}


### PR DESCRIPTION
Preserve selected released extension signatures while retaining the new schema filtering and SQL capabilities. Optional parameters and native return types can make existing subclass declarations fatal; separate filtering and cast entry points keep the selected override points usable.

- Keep schema collection accessor signatures and add `get_filtered_items()`, `get_filtered_columns()`, and `get_filtered_indexes()`. Filtering honors the existing accessors; Query also supports legacy schema classes exposing only `get_columns()`.
- Keep the familiar `get_create_table_string(bool $with_foreign_keys = false)` API, backed by a private `get_create_table_array()` builder. Inline table creation passes the flag through this method. This deliberately requires subclasses overriding the 3.0.0 method to accept the new optional flag.
- Limit Column compatibility repairs to APIs predating 3.0: parameterless `is_numeric()` and public datetime/decimal/UUID validators. Retain the expanded 3.0-only Column predicates and cast-aware `get_name_sql()`.
- Preserve selected untyped Query/helper signatures and add `get_sql_with_cast()`. Without a cast it honors existing `get_sql()` overrides; custom explicit-cast behavior requires overriding the new method. Tests and documentation make that boundary explicit.
- Add subclass and legacy-schema regression coverage, verify inline foreign-key SQL through Table::create(), and clarify lifecycle/strict-configuration migration notes.

Validation: PHP 8.1 and 8.2 with WordPress 6.7.7 each passed 1,770 tests / 3,912 assertions. PHPStan level 8, PHPCS, Composer validation, and diff checks passed. Reviewed through the local Copilot and Claude CLIs; addressed the confirmed regressions and GitHub Copilot's documentation comment.

The retained lifecycle changes, 3.0-only visibility changes, and old operator namespace migration remain separate release decisions.
